### PR TITLE
Implement save feature for pytorch classifier

### DIFF
--- a/art/classifiers/pytorch.py
+++ b/art/classifiers/pytorch.py
@@ -408,7 +408,21 @@ class PyTorchClassifier(Classifier):
         :type path: `str`
         :return: None
         """
-        raise NotImplementedError
+        import os
+        import torch
+
+        if path is None:
+            from art import DATA_PATH
+            full_path = os.path.join(DATA_PATH, filename)
+        else:
+            full_path = os.path.join(path, filename)
+        folder = os.path.split(full_path)[0]
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+        torch.save(self._model.state_dict(), full_path + '.model')
+        torch.save(self._optimizer.state_dict(), full_path + '.optimizer')
+        logger.info("Model state dict saved in path: %s.", full_path + '.model')
+        logger.info("Optimizer state dict saved in path: %s.", full_path + '.optimizer')
 
     # def _forward_at(self, inputs, layer):
     #     """

--- a/art/classifiers/pytorch_unittest.py
+++ b/art/classifiers/pytorch_unittest.py
@@ -200,6 +200,21 @@ class TestPyTorchClassifier(unittest.TestCase):
         self.assertTrue(ptc._model.training)
         self.assertTrue(ptc.learning_phase)
 
+    def test_save(self):
+        model = self.module_classifier
+        import tempfile
+        import os
+        t_file = tempfile.NamedTemporaryFile()
+        full_path = t_file.name
+        t_file.close()
+        base_name = os.path.basename(full_path)
+        dir_name = os.path.dirname(full_path)
+        model.save(base_name, path=dir_name)
+        self.assertTrue(os.path.exists(full_path + ".optimizer"))
+        self.assertTrue(os.path.exists(full_path + ".model"))
+        os.remove(full_path + '.optimizer')
+        os.remove(full_path + '.model')
+                                       
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now, save has been implemented for the Pytorch Classifier module and
it will save the optimizer and the model state dictionaries in the
specified path.  If not, it will save the above in the DATA_PATH
directory.

# Description
This will now allow pytorch classifier's model's and optimizer's state dictionaries to be saved with the name and path specified.  They will be suffixed with '.optimizer' and '.model' appropriately. 


Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [X ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Tried out the following and it works fine.
```
from art.classifiers import PyTorchClassifier
import torch
import torchvision.models as models
import torch.nn as nn
import torch.optim as optim

model = models.vgg11(pretrained=False)
loss = nn.MSELoss()
optimizer = optim.Adamax(model.parameters())

artClassifier = PyTorchClassifier((0,100), model, loss, optimizer, (1, 28, 28), 10)
artClassifier.save("dummy")
artClassifier.save("dummy",path="./weights")
```

**Test Configuration**:
- OS Ubuntu 18.04.1 LTS
- Python version 
- ART version or commit number : 120f95f
- PyTorch 1.0.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
