### PR TITLE
[New-Feature] Allowing for model weights to be loaded from the art.Classifier class 

### DIFF
--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -261,6 +261,22 @@ class Classifier(ABC):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def load_model_weights(self, filename, path=None):
+        """
+        Load a model to file in the format specific to the backend framework.
+
+        :param filename: Name of the file where to load the model's weights.
+        :type filename: `str`
+        :param path: Path of the folder where to store the model. If
+                     no path is specified, the model will be stored in
+                     the default data location of the library
+                     `DATA_PATH`.
+        :type path: `str`
+        :return: None
+        """
+        raise NotImplementedError
+
     def _parse_defences(self, defences):
         self.defences = defences
 

--- a/art/classifiers/classifier_unittest.py
+++ b/art/classifiers/classifier_unittest.py
@@ -33,6 +33,9 @@ class ClassifierInstance(Classifier):
     def save(self, filename, path=None):
         pass
 
+    def load_model_weights(self, filename, path=None):
+        pass
+
     def layer_names(self):
         pass
 

--- a/art/classifiers/ensemble.py
+++ b/art/classifiers/ensemble.py
@@ -249,3 +249,19 @@ class EnsembleClassifier(Classifier):
         :return: None
         """
         raise NotImplementedError
+
+    def load_model_weights(self, filename, path=None):
+        """
+        Load a model to file in the format specific to the backend framework.
+
+        :param filename: Name of the file where to load the model's weights.
+        :type filename: `str`
+        :param path: Path of the folder where to store the model. If
+                     no path is specified, the model will be stored in
+                     the default data location of the library
+                     `DATA_PATH`.
+        :type path: `str`
+        :return: None
+        """
+        raise NotImplementedError        
+    

--- a/art/classifiers/keras.py
+++ b/art/classifiers/keras.py
@@ -426,6 +426,21 @@ class KerasClassifier(Classifier):
         self._model.save(str(full_path))
         logger.info('Model saved in path: %s.', full_path)
 
+    def load_model_weights(self, filename, path=None):
+        """
+        Load a model to file in the format specific to the backend framework.
+
+        :param filename: Name of the file where to load the model's weights.
+        :type filename: `str`
+        :param path: Path of the folder where to store the model. If
+                     no path is specified, the model will be stored in
+                     the default data location of the library
+                     `DATA_PATH`.
+        :type path: `str`
+        :return: None
+        """
+        raise NotImplementedError        
+        
 
 def generator_fit(x, y, batch_size=128):
     """

--- a/art/classifiers/mxnet.py
+++ b/art/classifiers/mxnet.py
@@ -394,6 +394,22 @@ class MXClassifier(Classifier):
         """
         raise NotImplementedError
 
+    def load_model_weights(self, filename, path=None):
+        """
+        Load a model to file in the format specific to the backend framework.
+
+        :param filename: Name of the file where to load the model's weights.
+        :type filename: `str`
+        :param path: Path of the folder where to store the model. If
+                     no path is specified, the model will be stored in
+                     the default data location of the library
+                     `DATA_PATH`.
+        :type path: `str`
+        :return: None
+        """
+        raise NotImplementedError        
+    
+
     def _get_layers(self):
         """
         Return the hidden layers in the model, if applicable.

--- a/art/classifiers/pytorch.py
+++ b/art/classifiers/pytorch.py
@@ -424,6 +424,40 @@ class PyTorchClassifier(Classifier):
         logger.info("Model state dict saved in path: %s.", full_path + '.model')
         logger.info("Optimizer state dict saved in path: %s.", full_path + '.optimizer')
 
+    def load_model_weights(self, filename, path=None):
+        """
+        Load a model to file in the format specific to the backend
+        framework.  This follows the first method specified in:
+        https://pytorch.org/tutorials/beginner/saving_loading_models.html
+
+        :param filename: Name of the file where to load the model's
+        weights.  Note that the suffix `model` that was used must
+        *not* be given.  This is appended automatically so as to have
+        symmetry with the `save` function.
+
+        :type filename: `str`
+        :param path: Path of the folder where to store the model. If
+                     no path is specified, the model will be stored in
+                     the default data location of the library
+                     `DATA_PATH`.
+        :type path: `str`
+        :load_optimizer: `bool` : If true, load the optimizer state as well
+        :return: None
+
+        """
+        import os
+        import torch
+
+        if path is None:
+            from art import DATA_PATH
+            full_path = os.path.join(DATA_PATH, filename)
+        else:
+            full_path = os.path.join(path, filename)
+
+        self._model.load_state_dict(torch.load(os.path.abspath(full_path +
+                                                               '.model')))
+        logging.info("Model dict loaded from: %s", full_path + '.model')
+
     # def _forward_at(self, inputs, layer):
     #     """
     #     Compute the forward at a specific layer.

--- a/art/classifiers/tensorflow.py
+++ b/art/classifiers/tensorflow.py
@@ -463,3 +463,19 @@ class TFClassifier(Classifier):
         saver = tf.train.Saver()
         saver.save(self._sess, full_path)
         logger.info('Model saved in path: %s.', full_path)
+
+
+    def load_model_weights(self, filename, path=None):
+        """
+        Load a model to file in the format specific to the backend framework.
+
+        :param filename: Name of the file where to load the model's weights.
+        :type filename: `str`
+        :param path: Path of the folder where to store the model. If
+                     no path is specified, the model will be stored in
+                     the default data location of the library
+                     `DATA_PATH`.
+        :type path: `str`
+        :return: None
+        """
+        raise NotImplementedError        


### PR DESCRIPTION
# Description

Added a way to allow for loading model weights for art.classifer.Classifier.  This has the same type signature as the save and provides symmetry.

Fixes # (issue)

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Added a load test that instantiates a model, uses the art.classifier.Classifier wrapper and saves the weights.  Again instantiates and makes sure the weights are different.  After that, it loads the weights and checks if the loaded weights are the same as the one saved. 

**Test Configuration**:
- OS : GNU/Linux (Ubuntu 18.04)
- Python version: Python2.7/Python3.7
- ART version or commit number: 1.0.0 
- TensorFlow / Keras / PyTorch / MXNet version: Pytorch version 1.0.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
