### PR TITLE
Fix detector-for-CIFAR10.ipynb with the new detector implementation

### DIFF
--- a/notebooks/detector-for-CIFAR10.ipynb
+++ b/notebooks/detector-for-CIFAR10.ipynb
@@ -903,7 +903,7 @@
     }
    ],
    "source": [
-    "flag_adv = np.sum(np.argmax(detector(x_test_adv), axis=1) == 1)\n",
+    "flag_adv = np.sum(np.argmax(detector.predict(x_test_adv), axis=1) == 1)\n",
     "\n",
     "print(\"Adversarial test data (first 100 images):\")\n",
     "print(\"Flagged: {}\".format(flag_adv))\n",
@@ -933,7 +933,7 @@
     }
    ],
    "source": [
-    "flag_original = np.sum(np.argmax(detector(x_test[:100]), axis=1) == 1)\n",
+    "flag_original = np.sum(np.argmax(detector.predict(x_test[:100]), axis=1) == 1)\n",
     "\n",
     "print(\"Original test data (first 100 images):\")\n",
     "print(\"Flagged: {}\".format(flag_original))\n",
@@ -962,7 +962,7 @@
     "\n",
     "for eps in eps_range:\n",
     "    x_test_adv = attacker.generate(x_test[:100], eps=eps)\n",
-    "    nb_flag_adv += [np.sum(np.argmax(detector(x_test_adv), axis=1) == 1)]\n",
+    "    nb_flag_adv += [np.sum(np.argmax(detector.predict(x_test_adv), axis=1) == 1)]\n",
     "    nb_missclass += [np.sum(np.argmax(classifier.predict(x_test_adv), axis=1) != np.argmax(y_test[:100], axis=1))]\n",
     "    \n",
     "eps_range = [0] + eps_range\n",


### PR DESCRIPTION
# Description

Since ART 0.6, the detector class is extended from `Classifier`. However, the detector notebook didn't update with the new changes which it breaks during the last few cells. Therefore, I updated the last few cells to use the appropriate predict function from the latest detector class.

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] detector-for-CIFAR10.ipynb

**Test Configuration**:
- OS: OSX
- Python version: 3.7
- ART version or commit number: 0.7
- TensorFlow / Keras / PyTorch / MXNet version: TensorFlow 1.13.1

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
