### PR TITLE
Remove redundant parameter in adversarial patch

### DIFF
--- a/notebooks/adversarial_patch.ipynb
+++ b/notebooks/adversarial_patch.ipynb
@@ -64,7 +64,6 @@
    "outputs": [],
    "source": [
     "target_image_name = 'toaster.jpg'\n",
-    "patch_shape = (224, 224, 3)\n",
     "image_shape = (224, 224, 3)\n",
     "batch_size = 3\n",
     "scale_min = 0.3\n",
@@ -158,9 +157,10 @@
    },
    "outputs": [],
    "source": [
-    "ap = AdversarialPatch(classifier=tfc, target=name_to_label('toaster'), rotation_max=rotation_max, scale_min=scale_min,\n",
-    "                      scale_max=scale_max, learning_rate=learning_rate, max_iter=max_iter, patch_shape=patch_shape,\n",
-    "                      batch_size=batch_size, clip_patch=[(-103.939, 255.0 - 103.939), (-116.779, 255.0 - 116.779), (-123.680, 255.0 - 123.680)])\n",
+    "ap = AdversarialPatch(classifier=tfc, target=name_to_label('toaster'), rotation_max=rotation_max,\n",
+    "                      scale_min=scale_min, scale_max=scale_max, learning_rate=learning_rate, max_iter=max_iter,\n",
+    "                      batch_size=batch_size, clip_patch=[(-103.939, 255.0 - 103.939), (-116.779, 255.0 - 116.779),\n",
+    "                                                         (-123.680, 255.0 - 123.680)])\n",
     "patch, patch_mask = ap.generate(x=images)"
    ]
   },
@@ -372,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.10"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/tests/attacks/test_adversarial_patch.py
+++ b/tests/attacks/test_adversarial_patch.py
@@ -64,7 +64,7 @@ class TestAdversarialPatch(unittest.TestCase):
 
         # Attack
         attack_ap = AdversarialPatch(tfc, rotation_max=22.5, scale_min=0.1, scale_max=1.0, learning_rate=5.0,
-                                     patch_shape=(28, 28, 1), batch_size=10, max_iter=500)
+                                     batch_size=10, max_iter=500)
         patch_adv, _ = attack_ap.generate(x_train)
 
         self.assertTrue(patch_adv[8, 8, 0] - (-3.1106631027725005) < 0.01)
@@ -87,7 +87,7 @@ class TestAdversarialPatch(unittest.TestCase):
 
         # Attack
         attack_ap = AdversarialPatch(krc, rotation_max=22.5, scale_min=0.1, scale_max=1.0, learning_rate=5.0,
-                                     patch_shape=(28, 28, 1), batch_size=10, max_iter=500)
+                                     batch_size=10, max_iter=500)
         patch_adv, _ = attack_ap.generate(x_train)
 
         self.assertTrue(patch_adv[8, 8, 0] - (-3.2501425017774923) < 0.01)
@@ -110,7 +110,7 @@ class TestAdversarialPatch(unittest.TestCase):
 
         # Attack
         attack_ap = AdversarialPatch(ptc, rotation_max=22.5, scale_min=0.1, scale_max=1.0, learning_rate=5.0,
-                                     patch_shape=(1, 28, 28), batch_size=10, max_iter=500)
+                                     batch_size=10, max_iter=500)
         patch_adv, _ = attack_ap.generate(x_train)
 
         self.assertTrue(patch_adv[0, 8, 8] - (-3.1423605902784875) < 0.01)
@@ -119,7 +119,7 @@ class TestAdversarialPatch(unittest.TestCase):
 
     def test_failure_feature_vectors(self):
         attack_params = {"rotation_max": 22.5, "scale_min": 0.1, "scale_max": 1.0,
-                         "learning_rate": 5.0, "number_of_steps": 5, "patch_shape": (1, 28, 28), "batch_size": 10}
+                         "learning_rate": 5.0, "number_of_steps": 5, "batch_size": 10}
         attack = AdversarialPatch(classifier=None)
         attack.set_params(**attack_params)
         data = np.random.rand(10, 4)


### PR DESCRIPTION
# Description
The parameter `patch_shape` in the adversarial patch attack seems redundant, as the patch can only be created at the input size of the classifier. The patch is later rescaled to other dimensions in `apply_patch`. Having the parameter is misleading, as it creates the impression that the user can choose the initial size of the patch. I have thus removed it and changed the code to use the input size of the classifier instead. I have also updated the example notebook. This issue was brought forward by a user, see conversation in issue #77.

Fixes #77

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
- [X] Unit tests

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
