### PR TITLE
Improve compatibility between preprocessing defences and standardisation

### DIFF
--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -130,10 +130,10 @@ class Classifier(ABC):
             x, y = generator.get_batch()
 
             # Apply preprocessing and defences
-            x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
+            x_preprocessed, y_preprocessed = self._apply_preprocessing(x, y, fit=True)
 
             # Fit for current batch
-            self.fit(x_defences, y_defences, nb_epochs=1, batch_size=len(x), **kwargs)
+            self.fit(x_preprocessed, y_preprocessed, nb_epochs=1, batch_size=len(x), **kwargs)
 
     @property
     def nb_classes(self):
@@ -289,9 +289,9 @@ class Classifier(ABC):
         :return: Value of the data after applying the defences.
         :rtype: `np.ndarray`
         """
-        x_preproc = self._apply_preprocessing_normalization(x)
-        x_defences, y_defences = self._apply_preprocessing_defences(x_preproc, y, fit=fit)
-        return x_defences, y_defences, x_preproc
+        x_preprocessed, y_preprocessed = self._apply_preprocessing_defences(x, y, fit=fit)
+        x_preprocessed = self._apply_preprocessing_normalization(x_preprocessed)
+        return x_preprocessed, y_preprocessed
 
     def _apply_preprocessing_gradient(self, x, grads):
         """
@@ -305,8 +305,8 @@ class Classifier(ABC):
         :return: Value of the gradient.
         :rtype: `np.ndarray`
         """
-        grads = self._apply_preprocessing_defences_gradient(x, grads)
         grads = self._apply_preprocessing_normalization_gradient(grads)
+        grads = self._apply_preprocessing_defences_gradient(x, grads)
         return grads
 
     def _apply_preprocessing_defences(self, x, y, fit=False):

--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -130,11 +130,10 @@ class Classifier(ABC):
             x, y = generator.get_batch()
 
             # Apply preprocessing and defences
-            x = self._apply_processing(x)
-            x, y = self._apply_defences(x, y, fit=True)
+            x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
 
             # Fit for current batch
-            self.fit(x, y, nb_epochs=1, batch_size=len(x), **kwargs)
+            self.fit(x_defences, y_defences, nb_epochs=1, batch_size=len(x), **kwargs)
 
     @property
     def nb_classes(self):
@@ -279,13 +278,13 @@ class Classifier(ABC):
         raise NotImplementedError
 
     def _apply_preprocessing(self, x, y, fit):
-        x = self._apply_preprocessing_normalization(x)
-        x, y = self._apply_preprocessing_defences(x, y, fit=fit)
-        return x, y
+        x_preproc = self._apply_preprocessing_normalization(x)
+        x_defences, y_defences = self._apply_preprocessing_defences(x_preproc, y, fit=fit)
+        return x_defences, y_defences, x_preproc
 
     def _apply_preprocessing_gradient(self, x, grads):
         grads = self._apply_preprocessing_defences_gradient(x, grads)
-        grads = self._apply_preprocessing_processing_gradient(grads)
+        grads = self._apply_preprocessing_normalization_gradient(grads)
         return grads
 
     def _apply_preprocessing_defences(self, x, y, fit=False):

--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -33,6 +33,7 @@ class Classifier(ABC):
     """
     Base class for all classifiers.
     """
+
     def __init__(self, channel_index, clip_values=None, defences=None, preprocessing=(0, 1)):
         """
         Initialize a `Classifier` object.
@@ -389,7 +390,7 @@ class Classifier(ABC):
 
     def __repr__(self):
         repr_ = "%s(channel_index=%r, clip_values=%r, defences=%r, preprocessing=%r)" \
-               % (self.__module__ + '.' + self.__class__.__name__,
-                  self.channel_index, self.clip_values, self.defences, self.preprocessing)
+                % (self.__module__ + '.' + self.__class__.__name__,
+                   self.channel_index, self.clip_values, self.defences, self.preprocessing)
 
         return repr_

--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -278,7 +278,17 @@ class Classifier(ABC):
         """
         raise NotImplementedError
 
-    def _apply_defences(self, x, y, fit=False):
+    def _apply_preprocessing(self, x, y, fit):
+        x = self._apply_preprocessing_normalization(x)
+        x, y = self._apply_preprocessing_defences(x, y, fit=fit)
+        return x, y
+
+    def _apply_preprocessing_gradient(self, x, grads):
+        grads = self._apply_preprocessing_defences_gradient(x, grads)
+        grads = self._apply_preprocessing_processing_gradient(grads)
+        return grads
+
+    def _apply_preprocessing_defences(self, x, y, fit=False):
         """
         Apply the defences specified for the classifier in inputs `(x, y)`.
 
@@ -301,7 +311,7 @@ class Classifier(ABC):
 
         return x, y
 
-    def _apply_defences_gradient(self, x, grad, fit=False):
+    def _apply_preprocessing_defences_gradient(self, x, grad, fit=False):
         """
         Apply the backward pass through the preprocessing defences.
 
@@ -324,9 +334,9 @@ class Classifier(ABC):
 
         return grad
 
-    def _apply_processing(self, x):
+    def _apply_preprocessing_normalization(self, x):
         """
-        Apply the data preprocessing / normalization steps specified for the classifier on `x`.
+        Apply the data normalization steps specified for the classifier on `x`.
 
         :param x: Input data, where first dimension is the batch size.
         :type x: `np.ndarray`
@@ -342,9 +352,9 @@ class Classifier(ABC):
 
         return res
 
-    def _apply_processing_gradient(self, grad):
+    def _apply_preprocessing_normalization_gradient(self, grad):
         """
-        Apply the backward pass through the data preprocessing / normalization steps.
+        Apply the backward pass through the data normalization steps.
 
         :param grad: Gradient value so far.
         :type grad: `np.ndarray`

--- a/art/classifiers/detector_classifier.py
+++ b/art/classifiers/detector_classifier.py
@@ -14,6 +14,7 @@ class DetectorClassifier(Classifier):
     This class implements a Classifier extension that wraps a classifier and a detector.
     More details in https://arxiv.org/abs/1705.07263
     """
+
     def __init__(self, classifier, detector, defences=None, preprocessing=(0, 1)):
         """
         Initialization for the DetectorClassifier.
@@ -178,7 +179,8 @@ class DetectorClassifier(Classifier):
                 # Then compute the detector gradients for detector_idx
                 if len(detector_idx) > 0:
                     # First compute the classifier gradients for detector_idx
-                    classifier_grads = self.classifier.class_gradient(x=x_defences[detector_idx], label=None, logits=True)
+                    classifier_grads = self.classifier.class_gradient(x=x_defences[detector_idx], label=None,
+                                                                      logits=True)
 
                     # Then compute the detector gradients for detector_idx
                     detector_grads = self.detector.class_gradient(x=x_defences[detector_idx], label=0, logits=True)
@@ -220,7 +222,7 @@ class DetectorClassifier(Classifier):
                             si_lj = c * np.power(c + np.exp(combined_logits[:, i]), -2) * np.exp(combined_logits[:, i])
                         else:
                             si_lj = -np.exp(combined_logits[:, i]) * np.power(c + np.exp(combined_logits[:, j]), -2) * \
-                                np.exp(combined_logits[:, j])
+                                    np.exp(combined_logits[:, j])
                         si_grads += si_lj[:, None, None, None] * combined_logits_grads[:, j]
 
                     grads.append(si_grads)
@@ -233,10 +235,10 @@ class DetectorClassifier(Classifier):
                     c = sum_exp_logits - np.exp(combined_logits[:, j])
                     if j == label:
                         si_lj = c * np.power(c + np.exp(combined_logits[:, label]), -2) * \
-                            np.exp(combined_logits[:, label])
+                                np.exp(combined_logits[:, label])
                     else:
                         si_lj = -np.exp(combined_logits[:, label]) * np.power(c + np.exp(combined_logits[:, j]), -2) * \
-                            np.exp(combined_logits[:, j])
+                                np.exp(combined_logits[:, j])
                     si_grads += si_lj[:, None, None, None] * combined_logits_grads[:, j]
 
                 grads.append(si_grads)
@@ -252,7 +254,7 @@ class DetectorClassifier(Classifier):
                             si_lj = c * np.power(c + np.exp(combined_logits[:, i]), -2) * np.exp(combined_logits[:, i])
                         else:
                             si_lj = -np.exp(combined_logits[:, i]) * np.power(c + np.exp(combined_logits[:, j]), -2) * \
-                                np.exp(combined_logits[:, j])
+                                    np.exp(combined_logits[:, j])
                         si_grads += si_lj[:, None, None, None] * combined_logits_grads[:, j]
 
                     grads.append(si_grads)

--- a/art/classifiers/detector_classifier.py
+++ b/art/classifiers/detector_classifier.py
@@ -50,9 +50,8 @@ class DetectorClassifier(Classifier):
         :return: Array of predictions of shape `(nb_inputs, self.nb_classes)`.
         :rtype: `np.ndarray`
         """
-        # Apply defences
-        x_preproc = self._apply_processing(x)
-        x_defences, _ = self._apply_defences(x_preproc, None, fit=False)
+        # Apply preprocessing
+        x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Compute the prediction logits
         classifier_logits = self.classifier.predict(x=x_defences, logits=True, batch_size=batch_size)
@@ -126,8 +125,7 @@ class DetectorClassifier(Classifier):
             raise ValueError('Label %s is out of range.' % label)
 
         # Apply preprocessing
-        x_preproc = self._apply_processing(x)
-        x_defences, _ = self._apply_defences(x_preproc, None, fit=False)
+        x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
 
         # Compute the gradient and return
         if logits:
@@ -264,9 +262,7 @@ class DetectorClassifier(Classifier):
                 grads = grads[np.arange(len(grads)), lst]
                 combined_grads = np.expand_dims(grads, axis=1)
 
-        # Apply gradient post-processing
-        combined_grads = self._apply_defences_gradient(x_preproc, combined_grads)
-        combined_grads = self._apply_processing_gradient(combined_grads)
+        combined_grads = self._apply_preprocessing_gradient(x_preproc, combined_grads)
 
         return combined_grads
 

--- a/art/classifiers/detector_classifier.py
+++ b/art/classifiers/detector_classifier.py
@@ -52,7 +52,7 @@ class DetectorClassifier(Classifier):
         :rtype: `np.ndarray`
         """
         # Apply preprocessing
-        x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
+        x_defences, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Compute the prediction logits
         classifier_logits = self.classifier.predict(x=x_defences, logits=True, batch_size=batch_size)
@@ -126,7 +126,7 @@ class DetectorClassifier(Classifier):
             raise ValueError('Label %s is out of range.' % label)
 
         # Apply preprocessing
-        x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
+        x_defences, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Compute the gradient and return
         if logits:
@@ -264,7 +264,7 @@ class DetectorClassifier(Classifier):
                 grads = grads[np.arange(len(grads)), lst]
                 combined_grads = np.expand_dims(grads, axis=1)
 
-        combined_grads = self._apply_preprocessing_gradient(x_preproc, combined_grads)
+        combined_grads = self._apply_preprocessing_gradient(x, combined_grads)
 
         return combined_grads
 

--- a/art/classifiers/keras.py
+++ b/art/classifiers/keras.py
@@ -301,7 +301,7 @@ class KerasClassifier(Classifier):
 
         # Adjust the shape of y for loss functions that do not take labels in one-hot encoding
         if self._reduce_labels:
-            y_defences = np.argmax(y_preprocessed, axis=1)
+            y_preprocessed = np.argmax(y_preprocessed, axis=1)
 
         gen = generator_fit(x_preprocessed, y_preprocessed, batch_size)
         self._model.fit_generator(gen, steps_per_epoch=x_preprocessed.shape[0] / batch_size, epochs=nb_epochs, **kwargs)

--- a/art/classifiers/keras.py
+++ b/art/classifiers/keras.py
@@ -31,6 +31,7 @@ class KerasClassifier(Classifier):
     """
     Wrapper class for importing Keras models. The supported backends for Keras are TensorFlow and Theano.
     """
+
     def __init__(self, model, use_logits=False, channel_index=3, clip_values=None, defences=None, preprocessing=(0, 1),
                  input_layer=0, output_layer=0, custom_activation=False):
         """

--- a/art/classifiers/keras.py
+++ b/art/classifiers/keras.py
@@ -173,12 +173,14 @@ class KerasClassifier(Classifier):
         :return: Array of gradients of the same shape as `x`.
         :rtype: `np.ndarray`
         """
+        # Apply preprocessing
         x_defences, y_defences, x_preproc = self._apply_preprocessing(x, y, fit=False)
 
         # Adjust the shape of y for loss functions that do not take labels in one-hot encoding
         if self._reduce_labels:
             y_defences = np.argmax(y_defences, axis=1)
 
+        # Compute gradients
         grads = self._loss_grads([x_defences, y_defences])[0]
         grads = self._apply_preprocessing_gradient(x_preproc, grads)
         assert grads.shape == x_preproc.shape
@@ -211,6 +213,7 @@ class KerasClassifier(Classifier):
 
         self._init_class_grads(label=label, logits=logits)
 
+        # Apply preprocessing
         x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
 
         if label is None:
@@ -377,12 +380,12 @@ class KerasClassifier(Classifier):
         layer_output = self._model.get_layer(layer_name).output
         output_func = k.function([self._input], [layer_output])
 
-        # Apply preprocessing and defences
         if x.shape == self.input_shape:
             x_expanded = np.expand_dims(x, 0)
         else:
             x_expanded = x
 
+        # Apply preprocessing
         x_defences, _, _ = self._apply_preprocessing(x=x_expanded, y=None, fit=False)
 
         assert len(x_defences.shape) == 4

--- a/art/classifiers/mxnet.py
+++ b/art/classifiers/mxnet.py
@@ -106,7 +106,7 @@ class MXClassifier(Classifier):
 
         train_mode = self._learning_phase if hasattr(self, '_learning_phase') else True
 
-        # Apply preprocessing and defences
+        # Apply preprocessing
         x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
 
         y_defences = np.argmax(y_defences, axis=1)
@@ -188,7 +188,7 @@ class MXClassifier(Classifier):
 
         train_mode = self._learning_phase if hasattr(self, '_learning_phase') else False
 
-        # Apply preprocessing and defences
+        # Apply preprocessing
         x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing
@@ -239,6 +239,7 @@ class MXClassifier(Classifier):
 
         train_mode = self._learning_phase if hasattr(self, '_learning_phase') else False
 
+        # Apply preprocessing
         x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
 
         x_defences = mx.nd.array(x_defences.astype(NUMPY_DTYPE), ctx=self._ctx)
@@ -308,6 +309,7 @@ class MXClassifier(Classifier):
 
         train_mode = self._learning_phase if hasattr(self, '_learning_phase') else False
 
+        # Apply preprocessing
         x_defences, y_defences, x_preproc = self._apply_preprocessing(x, y, fit=False)
 
         y_defences = mx.nd.array([np.argmax(y_defences, axis=1)]).T
@@ -320,6 +322,8 @@ class MXClassifier(Classifier):
             loss = loss(preds, y_defences)
 
         loss.backward()
+
+        # Compute gradients
         grads = x_defences.grad.asnumpy()
         grads = self._apply_preprocessing_gradient(x_preproc, grads)
         assert grads.shape == x.shape

--- a/art/classifiers/mxnet.py
+++ b/art/classifiers/mxnet.py
@@ -32,6 +32,7 @@ class MXClassifier(Classifier):
     """
     Wrapper class for importing MXNet Gluon model.
     """
+
     def __init__(self, model, input_shape, nb_classes, optimizer=None, ctx=None, channel_index=1, clip_values=None,
                  defences=None, preprocessing=(0, 1)):
         """
@@ -382,7 +383,7 @@ class MXClassifier(Classifier):
         else:
             x_expanded = x
 
-        x_preprocessed, _= self._apply_preprocessing(x=x_expanded, y=None, fit=False)
+        x_preprocessed, _ = self._apply_preprocessing(x=x_expanded, y=None, fit=False)
 
         # Compute activations with batching
         activations = []

--- a/art/classifiers/pytorch.py
+++ b/art/classifiers/pytorch.py
@@ -100,7 +100,7 @@ class PyTorchClassifier(Classifier):
         """
         import torch
 
-        # Apply defences
+        # Apply preprocessing
         x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing
@@ -139,7 +139,7 @@ class PyTorchClassifier(Classifier):
         """
         import torch
 
-        # Apply defences
+        # Apply preprocessing
         x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
 
         y_defences = np.argmax(y_defences, axis=1)
@@ -234,7 +234,7 @@ class PyTorchClassifier(Classifier):
                     and label.shape[0] == x.shape[0])):
             raise ValueError('Label %s is out of range.' % label)
 
-        # Convert the inputs to Tensors
+        # Apply preprocessing
         x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
 
         x_defences = torch.from_numpy(x_defences).to(self._device).float()
@@ -312,7 +312,7 @@ class PyTorchClassifier(Classifier):
         """
         import torch
 
-        # Apply preprocessing and defences
+        # Apply preprocessing
         x_defences, y_defences, x_preproc = self._apply_preprocessing(x, y, fit=False)
 
         # Convert the inputs to Tensors

--- a/art/classifiers/pytorch.py
+++ b/art/classifiers/pytorch.py
@@ -101,17 +101,16 @@ class PyTorchClassifier(Classifier):
         import torch
 
         # Apply defences
-        x_preproc = self._apply_processing(x)
-        x_preproc, _ = self._apply_defences(x_preproc, None, fit=False)
+        x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing
-        results = np.zeros((x_preproc.shape[0], self.nb_classes), dtype=np.float32)
-        num_batch = int(np.ceil(len(x_preproc) / float(batch_size)))
+        results = np.zeros((x_defences.shape[0], self.nb_classes), dtype=np.float32)
+        num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
         for m in range(num_batch):
             # Batch indexes
-            begin, end = m * batch_size, min((m + 1) * batch_size, x_preproc.shape[0])
+            begin, end = m * batch_size, min((m + 1) * batch_size, x_defences.shape[0])
 
-            model_outputs = self._model(torch.from_numpy(x_preproc[begin:end]).to(self._device).float())
+            model_outputs = self._model(torch.from_numpy(x_defences[begin:end]).to(self._device).float())
             (logit_output, output) = (model_outputs[-2], model_outputs[-1])
 
             if logits:
@@ -141,12 +140,12 @@ class PyTorchClassifier(Classifier):
         import torch
 
         # Apply defences
-        x_preproc = self._apply_processing(x)
-        x_preproc, y_preproc = self._apply_defences(x_preproc, y, fit=True)
-        y_preproc = np.argmax(y_preproc, axis=1)
+        x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
 
-        num_batch = int(np.ceil(len(x_preproc) / float(batch_size)))
-        ind = np.arange(len(x_preproc))
+        y_defences = np.argmax(y_defences, axis=1)
+
+        num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
+        ind = np.arange(len(x_defences))
 
         # Start training
         for _ in range(nb_epochs):
@@ -155,8 +154,8 @@ class PyTorchClassifier(Classifier):
 
             # Train for one epoch
             for m in range(num_batch):
-                i_batch = torch.from_numpy(x_preproc[ind[m * batch_size:(m + 1) * batch_size]]).to(self._device).float()
-                o_batch = torch.from_numpy(y_preproc[ind[m * batch_size:(m + 1) * batch_size]]).to(self._device)
+                i_batch = torch.from_numpy(x_defences[ind[m * batch_size:(m + 1) * batch_size]]).to(self._device).float()
+                o_batch = torch.from_numpy(y_defences[ind[m * batch_size:(m + 1) * batch_size]]).to(self._device)
 
                 # Zero the parameter gradients
                 self._optimizer.zero_grad()
@@ -236,8 +235,8 @@ class PyTorchClassifier(Classifier):
             raise ValueError('Label %s is out of range.' % label)
 
         # Convert the inputs to Tensors
-        x_preproc = self._apply_processing(x)
-        x_defences, _ = self._apply_defences(x_preproc, None, fit=False)
+        x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
+
         x_defences = torch.from_numpy(x_defences).to(self._device).float()
 
         # Compute gradient wrt what
@@ -296,8 +295,7 @@ class PyTorchClassifier(Classifier):
             grads = grads[None, ...]
 
         grads = np.swapaxes(np.array(grads), 0, 1)
-        grads = self._apply_defences_gradient(x_preproc, grads)
-        grads = self._apply_processing_gradient(grads)
+        grads = self._apply_preprocessing_gradient(x_preproc, grads)
 
         return grads
 
@@ -315,8 +313,7 @@ class PyTorchClassifier(Classifier):
         import torch
 
         # Apply preprocessing and defences
-        x_preproc = self._apply_processing(x)
-        x_defences, y_ = self._apply_defences(x_preproc, y, fit=False)
+        x_defences, y_defences, x_preproc = self._apply_preprocessing(x, y, fit=False)
 
         # Convert the inputs to Tensors
         inputs_t = torch.from_numpy(x_defences).to(self._device)
@@ -324,7 +321,7 @@ class PyTorchClassifier(Classifier):
         inputs_t.requires_grad = True
 
         # Convert the labels to Tensors
-        labels_t = torch.from_numpy(np.argmax(y_, axis=1)).to(self._device)
+        labels_t = torch.from_numpy(np.argmax(y_defences, axis=1)).to(self._device)
 
         # Compute the gradient and return
         model_outputs = self._model(inputs_t)
@@ -335,12 +332,11 @@ class PyTorchClassifier(Classifier):
 
         # Compute gradients
         loss.backward()
-        grds = inputs_t.grad.cpu().numpy().copy()
-        grds = self._apply_defences_gradient(x_preproc, grds)
-        grds = self._apply_processing_gradient(grds)
-        assert grds.shape == x.shape
+        grads = inputs_t.grad.cpu().numpy().copy()
+        grads = self._apply_preprocessing_gradient(x_preproc, grads)
+        assert grads.shape == x.shape
 
-        return grds
+        return grads
 
     @property
     def layer_names(self):
@@ -376,8 +372,7 @@ class PyTorchClassifier(Classifier):
         import torch
 
         # Apply defences
-        x_preproc = self._apply_processing(x)
-        x_preproc, _ = self._apply_defences(x_preproc, None, fit=False)
+        x_defences, _, _ = self._apply_preprocessing(x=x, y=None, fit=False)
 
         # Get index of the extracted layer
         if isinstance(layer, six.string_types):
@@ -393,13 +388,13 @@ class PyTorchClassifier(Classifier):
 
         # Run prediction with batch processing
         results = []
-        num_batch = int(np.ceil(len(x_preproc) / float(batch_size)))
+        num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
         for m in range(num_batch):
             # Batch indexes
-            begin, end = m * batch_size, min((m + 1) * batch_size, x_preproc.shape[0])
+            begin, end = m * batch_size, min((m + 1) * batch_size, x_defences.shape[0])
 
             # Run prediction for the current batch
-            layer_output = self._model(torch.from_numpy(x_preproc[begin:end]).to(self._device).float())[layer_index]
+            layer_output = self._model(torch.from_numpy(x_defences[begin:end]).to(self._device).float())[layer_index]
             results.append(layer_output.detach().cpu().numpy())
 
         results = np.concatenate(results)

--- a/art/classifiers/pytorch.py
+++ b/art/classifiers/pytorch.py
@@ -32,6 +32,7 @@ class PyTorchClassifier(Classifier):
     """
     This class implements a classifier with the PyTorch framework.
     """
+
     def __init__(self, model, loss, optimizer, input_shape, nb_classes, channel_index=1, clip_values=None,
                  defences=None, preprocessing=(0, 1)):
         """
@@ -154,7 +155,8 @@ class PyTorchClassifier(Classifier):
 
             # Train for one epoch
             for m in range(num_batch):
-                i_batch = torch.from_numpy(x_preprocessed[ind[m * batch_size:(m + 1) * batch_size]]).to(self._device).float()
+                i_batch = torch.from_numpy(x_preprocessed[ind[m * batch_size:(m + 1) * batch_size]]).to(
+                    self._device).float()
                 o_batch = torch.from_numpy(y_preprocessed[ind[m * batch_size:(m + 1) * batch_size]]).to(self._device)
 
                 # Zero the parameter gradients
@@ -394,7 +396,8 @@ class PyTorchClassifier(Classifier):
             begin, end = m * batch_size, min((m + 1) * batch_size, x_preprocessed.shape[0])
 
             # Run prediction for the current batch
-            layer_output = self._model(torch.from_numpy(x_preprocessed[begin:end]).to(self._device).float())[layer_index]
+            layer_output = self._model(torch.from_numpy(x_preprocessed[begin:end]).to(self._device).float())[
+                layer_index]
             results.append(layer_output.detach().cpu().numpy())
 
         results = np.concatenate(results)

--- a/art/classifiers/tensorflow.py
+++ b/art/classifiers/tensorflow.py
@@ -15,6 +15,7 @@ class TFClassifier(Classifier):
     """
     This class implements a classifier with the Tensorflow framework.
     """
+
     def __init__(self, input_ph, logits, output_ph=None, train=None, loss=None, learning=None, sess=None,
                  channel_index=3, clip_values=None, defences=None, preprocessing=(0, 1)):
         """
@@ -348,12 +349,12 @@ class TFClassifier(Classifier):
 
         for op in ops:
             filter_cond = ((op.values()) and (not op.values()[0].get_shape() == None) and (
-                len(op.values()[0].get_shape().as_list()) > 1) and (
-                    op.values()[0].get_shape().as_list()[0] is None) and (
-                    op.values()[0].get_shape().as_list()[1] is not None) and (
-                    not op.values()[0].name.startswith("gradients")) and (
-                    not op.values()[0].name.startswith("softmax_cross_entropy_loss")) and (
-                    not op.type == "Placeholder"))
+                    len(op.values()[0].get_shape().as_list()) > 1) and (
+                                   op.values()[0].get_shape().as_list()[0] is None) and (
+                                   op.values()[0].get_shape().as_list()[1] is not None) and (
+                               not op.values()[0].name.startswith("gradients")) and (
+                               not op.values()[0].name.startswith("softmax_cross_entropy_loss")) and (
+                               not op.type == "Placeholder"))
 
             if filter_cond:
                 tmp_list.append(op.values()[0].name)

--- a/art/classifiers/tensorflow.py
+++ b/art/classifiers/tensorflow.py
@@ -349,12 +349,12 @@ class TFClassifier(Classifier):
 
         for op in ops:
             filter_cond = ((op.values()) and (not op.values()[0].get_shape() == None) and (
-                    len(op.values()[0].get_shape().as_list()) > 1) and (
-                                   op.values()[0].get_shape().as_list()[0] is None) and (
-                                   op.values()[0].get_shape().as_list()[1] is not None) and (
-                               not op.values()[0].name.startswith("gradients")) and (
-                               not op.values()[0].name.startswith("softmax_cross_entropy_loss")) and (
-                               not op.type == "Placeholder"))
+                len(op.values()[0].get_shape().as_list()) > 1) and (
+                        op.values()[0].get_shape().as_list()[0] is None) and (
+                                       op.values()[0].get_shape().as_list()[1] is not None) and (
+                                       not op.values()[0].name.startswith("gradients")) and (
+                                   not op.values()[0].name.startswith("softmax_cross_entropy_loss")) and (
+                                   not op.type == "Placeholder"))
 
             if filter_cond:
                 tmp_list.append(op.values()[0].name)

--- a/art/classifiers/tensorflow.py
+++ b/art/classifiers/tensorflow.py
@@ -95,7 +95,7 @@ class TFClassifier(Classifier):
         :return: Array of predictions of shape `(nb_inputs, self.nb_classes)`.
         :rtype: `np.ndarray`
         """
-        # Apply defences
+        # Apply preprocessing
         x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing
@@ -138,7 +138,7 @@ class TFClassifier(Classifier):
         if self._train is None or self._output_ph is None:
             raise ValueError("Need the training objective and the output placeholder to train the model.")
 
-        # Apply defences
+        # Apply preprocessing
         x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
 
         num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
@@ -218,6 +218,7 @@ class TFClassifier(Classifier):
 
         self._init_class_grads(label=label, logits=logits)
 
+        # Apply preprocessing
         x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
 
         # Create feed_dict
@@ -269,6 +270,7 @@ class TFClassifier(Classifier):
         :return: Array of gradients of the same shape as `x`.
         :rtype: `np.ndarray`
         """
+        # Apply preprocessing
         x_defences, y_defences, x_preproc = self._apply_preprocessing(x, y, fit=False)
 
         # Check if loss available
@@ -279,7 +281,7 @@ class TFClassifier(Classifier):
         fd = {self._input_ph: x_defences, self._output_ph: y_defences}
         fd.update(self._feed_dict)
 
-        # Compute the gradient and return
+        # Compute gradients
         grads = self._sess.run(self._loss_grads, feed_dict=fd)
         grads = self._apply_preprocessing_gradient(x_preproc, grads)
         assert grads.shape == x_preproc.shape
@@ -415,7 +417,7 @@ class TFClassifier(Classifier):
         else:
             raise TypeError("Layer must be of type `str` or `int`. Received '%s'", layer)
 
-        # Apply preprocessing and defences
+        # Apply preprocessing
         x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing

--- a/art/classifiers/tensorflow.py
+++ b/art/classifiers/tensorflow.py
@@ -96,18 +96,17 @@ class TFClassifier(Classifier):
         :rtype: `np.ndarray`
         """
         # Apply defences
-        x_preproc = self._apply_processing(x)
-        x_preproc, _ = self._apply_defences(x_preproc, None, fit=False)
+        x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing
-        results = np.zeros((x_preproc.shape[0], self.nb_classes), dtype=np.float32)
-        num_batch = int(np.ceil(len(x_preproc) / float(batch_size)))
+        results = np.zeros((x_defences.shape[0], self.nb_classes), dtype=np.float32)
+        num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
         for m in range(num_batch):
             # Batch indexes
-            begin, end = m * batch_size, min((m + 1) * batch_size, x_preproc.shape[0])
+            begin, end = m * batch_size, min((m + 1) * batch_size, x_defences.shape[0])
 
             # Create feed_dict
-            fd = {self._input_ph: x_preproc[begin:end]}
+            fd = {self._input_ph: x_defences[begin:end]}
             fd.update(self._feed_dict)
 
             # Run prediction
@@ -140,11 +139,10 @@ class TFClassifier(Classifier):
             raise ValueError("Need the training objective and the output placeholder to train the model.")
 
         # Apply defences
-        x_preproc = self._apply_processing(x)
-        x_preproc, y_preproc = self._apply_defences(x_preproc, y, fit=True)
+        x_defences, y_defences, _ = self._apply_preprocessing(x, y, fit=True)
 
-        num_batch = int(np.ceil(len(x_preproc) / float(batch_size)))
-        ind = np.arange(len(x_preproc))
+        num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
+        ind = np.arange(len(x_defences))
 
         # Start training
         for _ in range(nb_epochs):
@@ -153,8 +151,8 @@ class TFClassifier(Classifier):
 
             # Train for one epoch
             for m in range(num_batch):
-                i_batch = x_preproc[ind[m * batch_size:(m + 1) * batch_size]]
-                o_batch = y_preproc[ind[m * batch_size:(m + 1) * batch_size]]
+                i_batch = x_defences[ind[m * batch_size:(m + 1) * batch_size]]
+                o_batch = y_defences[ind[m * batch_size:(m + 1) * batch_size]]
 
                 # Create feed_dict
                 fd = {self._input_ph: i_batch, self._output_ph: o_batch}
@@ -220,8 +218,7 @@ class TFClassifier(Classifier):
 
         self._init_class_grads(label=label, logits=logits)
 
-        x_preproc = self._apply_processing(x)
-        x_defences, _ = self._apply_defences(x_preproc, None)
+        x_defences, _, x_preproc = self._apply_preprocessing(x, y=None, fit=False)
 
         # Create feed_dict
         fd = {self._input_ph: x_defences}
@@ -257,8 +254,7 @@ class TFClassifier(Classifier):
             lst = [unique_label.index(i) for i in label]
             grads = np.expand_dims(grads[np.arange(len(grads)), lst], axis=1)
 
-        grads = self._apply_defences_gradient(x_preproc, grads)
-        grads = self._apply_processing_gradient(grads)
+        grads = self._apply_preprocessing_gradient(x_preproc, grads)
 
         return grads
 
@@ -273,24 +269,22 @@ class TFClassifier(Classifier):
         :return: Array of gradients of the same shape as `x`.
         :rtype: `np.ndarray`
         """
-        x_preproc = self._apply_processing(x)
-        x_defences, y_ = self._apply_defences(x_preproc, y, fit=False)
+        x_defences, y_defences, x_preproc = self._apply_preprocessing(x, y, fit=False)
 
         # Check if loss available
         if not hasattr(self, '_loss_grads') or self._loss_grads is None or self._output_ph is None:
             raise ValueError("Need the loss function and the labels placeholder to compute the loss gradient.")
 
         # Create feed_dict
-        fd = {self._input_ph: x_defences, self._output_ph: y_}
+        fd = {self._input_ph: x_defences, self._output_ph: y_defences}
         fd.update(self._feed_dict)
 
         # Compute the gradient and return
-        grds = self._sess.run(self._loss_grads, feed_dict=fd)
-        grds = self._apply_defences_gradient(x_preproc, grds)
-        grds = self._apply_processing_gradient(grds)
-        assert grds.shape == x_preproc.shape
+        grads = self._sess.run(self._loss_grads, feed_dict=fd)
+        grads = self._apply_preprocessing_gradient(x_preproc, grads)
+        assert grads.shape == x_preproc.shape
 
-        return grds
+        return grads
 
     def _init_class_grads(self, label=None, logits=False):
         import tensorflow as tf
@@ -422,18 +416,17 @@ class TFClassifier(Classifier):
             raise TypeError("Layer must be of type `str` or `int`. Received '%s'", layer)
 
         # Apply preprocessing and defences
-        x_preproc = self._apply_processing(x)
-        x_preproc, _ = self._apply_defences(x_preproc, None, fit=False)
+        x_defences, _, _ = self._apply_preprocessing(x, y=None, fit=False)
 
         # Run prediction with batch processing
         results = []
-        num_batch = int(np.ceil(len(x_preproc) / float(batch_size)))
+        num_batch = int(np.ceil(len(x_defences) / float(batch_size)))
         for m in range(num_batch):
             # Batch indexes
-            begin, end = m * batch_size, min((m + 1) * batch_size, x_preproc.shape[0])
+            begin, end = m * batch_size, min((m + 1) * batch_size, x_defences.shape[0])
 
             # Create feed_dict
-            fd = {self._input_ph: x_preproc[begin:end]}
+            fd = {self._input_ph: x_defences[begin:end]}
             fd.update(self._feed_dict)
 
             # Run prediction for the current batch

--- a/art/defences/adversarial_trainer.py
+++ b/art/defences/adversarial_trainer.py
@@ -36,6 +36,7 @@ class AdversarialTrainer:
      .. warning:: Both successful and unsuccessful adversarial samples are used for training. In the case of
                   unbounded attacks (e.g., DeepFool), this can result in invalid (very noisy) samples being included.
     """
+
     def __init__(self, classifier, attacks, ratio=.5):
         """
         Create an :class:`.AdversarialTrainer` instance.

--- a/art/defences/feature_squeezing.py
+++ b/art/defences/feature_squeezing.py
@@ -101,7 +101,6 @@ class FeatureSqueezing(Preprocessor):
         :type apply_fit: `bool`
         :param apply_predict: True if applied during predicting.
         :type apply_predict: `bool`
-
         """
         # Save defence-specific parameters
         super(FeatureSqueezing, self).set_params(**kwargs)

--- a/art/defences/feature_squeezing.py
+++ b/art/defences/feature_squeezing.py
@@ -30,29 +30,34 @@ class FeatureSqueezing(Preprocessor):
     """
     Reduces the sensibility of the features of a sample. Defence method from https://arxiv.org/abs/1704.01155.
     """
-    params = ['bit_depth', 'clip_values']
+    params = ['clip_values', 'bit_depth', '_apply_fit', '_apply_predict']
 
-    def __init__(self, bit_depth=8, clip_values=(0, 1)):
+    def __init__(self, clip_values, bit_depth=8, apply_fit=False, apply_predict=True):
         """
         Create an instance of feature squeezing.
 
-        :param bit_depth: The number of bits per channel for encoding the data.
-        :type bit_depth: `int`
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
+        :param bit_depth: The number of bits per channel for encoding the data.
+        :type bit_depth: `int`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(FeatureSqueezing, self).__init__()
         self._is_fitted = True
-        self.set_params(bit_depth=bit_depth, clip_values=clip_values)
+        self.set_params(clip_values=clip_values, bit_depth=bit_depth, _apply_fit=apply_fit,
+                        _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
-        return False
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return True
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """
@@ -66,11 +71,13 @@ class FeatureSqueezing(Preprocessor):
         :rtype: `np.ndarray`
         """
         x_ = x - self.clip_values[0]
-        if self.clip_values[1] != 0:
-            x_ = x_ / (self.clip_values[1] - self.clip_values[0])
+        x_ = x_ / (self.clip_values[1] - self.clip_values[0])
 
         max_value = np.rint(2 ** self.bit_depth - 1)
         res = (np.rint(x_ * max_value) / max_value) * (self.clip_values[1] - self.clip_values[0]) + self.clip_values[0]
+
+        res = res * (self.clip_values[1] - self.clip_values[0])
+        res = res + self.clip_values[0]
 
         return res, y
 
@@ -85,11 +92,16 @@ class FeatureSqueezing(Preprocessor):
         """
         Take in a dictionary of parameters and applies defence-specific checks before saving them as attributes.
 
-        :param bit_depth: The number of bits per channel for encoding the data.
-        :type bit_depth: `int`
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
+        :param bit_depth: The number of bits per channel for encoding the data.
+        :type bit_depth: `int`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
+
         """
         # Save defence-specific parameters
         super(FeatureSqueezing, self).set_params(**kwargs)
@@ -99,6 +111,7 @@ class FeatureSqueezing(Preprocessor):
 
         if len(self.clip_values) != 2:
             raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
+
         if np.array(self.clip_values[0] >= self.clip_values[1]).any():
             raise ValueError('Invalid `clip_values`: min >= max.')
 

--- a/art/defences/feature_squeezing.py
+++ b/art/defences/feature_squeezing.py
@@ -70,11 +70,11 @@ class FeatureSqueezing(Preprocessor):
         :return: Squeezed sample.
         :rtype: `np.ndarray`
         """
-        x_ = x - self.clip_values[0]
-        x_ = x_ / (self.clip_values[1] - self.clip_values[0])
+        x_normalized = x - self.clip_values[0]
+        x_normalized = x_normalized / (self.clip_values[1] - self.clip_values[0])
 
         max_value = np.rint(2 ** self.bit_depth - 1)
-        res = (np.rint(x_ * max_value) / max_value)
+        res = (np.rint(x_normalized * max_value) / max_value)
 
         res = res * (self.clip_values[1] - self.clip_values[0])
         res = res + self.clip_values[0]

--- a/art/defences/feature_squeezing.py
+++ b/art/defences/feature_squeezing.py
@@ -30,7 +30,7 @@ class FeatureSqueezing(Preprocessor):
     """
     Reduces the sensibility of the features of a sample. Defence method from https://arxiv.org/abs/1704.01155.
     """
-    params = ['clip_values', 'bit_depth', '_apply_fit', '_apply_predict']
+    params = ['clip_values', 'bit_depth']
 
     def __init__(self, clip_values, bit_depth=8, apply_fit=False, apply_predict=True):
         """
@@ -48,8 +48,9 @@ class FeatureSqueezing(Preprocessor):
         """
         super(FeatureSqueezing, self).__init__()
         self._is_fitted = True
-        self.set_params(clip_values=clip_values, bit_depth=bit_depth, _apply_fit=apply_fit,
-                        _apply_predict=apply_predict)
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(clip_values=clip_values, bit_depth=bit_depth)
 
     @property
     def apply_fit(self):
@@ -97,10 +98,6 @@ class FeatureSqueezing(Preprocessor):
         :type clip_values: `tuple`
         :param bit_depth: The number of bits per channel for encoding the data.
         :type bit_depth: `int`
-        :param apply_fit: True if applied during fitting/training.
-        :type apply_fit: `bool`
-        :param apply_predict: True if applied during predicting.
-        :type apply_predict: `bool`
         """
         # Save defence-specific parameters
         super(FeatureSqueezing, self).set_params(**kwargs)

--- a/art/defences/feature_squeezing.py
+++ b/art/defences/feature_squeezing.py
@@ -74,7 +74,7 @@ class FeatureSqueezing(Preprocessor):
         x_ = x_ / (self.clip_values[1] - self.clip_values[0])
 
         max_value = np.rint(2 ** self.bit_depth - 1)
-        res = (np.rint(x_ * max_value) / max_value) * (self.clip_values[1] - self.clip_values[0]) + self.clip_values[0]
+        res = (np.rint(x_ * max_value) / max_value)
 
         res = res * (self.clip_values[1] - self.clip_values[0])
         res = res + self.clip_values[0]

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -57,8 +57,12 @@ class GaussianAugmentation(Preprocessor):
         """
         super(GaussianAugmentation, self).__init__()
         self._is_fitted = True
-        self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio, clip_values=clip_values,
-                        _apply_fit=apply_fit, _apply_predict=apply_predict)
+        if self.augmentation and self.apply_fit and self.apply_predict:
+            raise ValueError("If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`"
+                             " must be `False`.")
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio, clip_values=clip_values)
 
     @property
     def apply_fit(self):
@@ -130,20 +134,12 @@ class GaussianAugmentation(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
-        :param apply_fit: True if applied during fitting/training.
-        :type apply_fit: `bool`
-        :param apply_predict: True if applied during predicting.
-        :type apply_predict: `bool`
         """
         # Save attack-specific parameters
         super(GaussianAugmentation, self).set_params(**kwargs)
 
         if self.augmentation and self.ratio <= 0:
             raise ValueError("The augmentation ratio must be positive.")
-
-        if self.augmentation and self.apply_fit and self.apply_predict:
-            raise ValueError("If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`"
-                             " must be `False`.")
 
         if self.clip_values is not None:
 

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -47,10 +47,8 @@ class GaussianAugmentation(Preprocessor):
         :param ratio: Percentage of data augmentation. E.g. for a rate of 1, the size of the dataset will double.
                       If `augmentation` is false, `ratio` value is ignored.
         :type ratio: `float`
-        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
-               maximum values allowed for features. If floats are provided, these will be used as the range of all
-               features. If arrays are provided, each value will be considered the bound for a feature, thus
-               the shape of clip values needs to match the total number of features.
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
         :type clip_values: `tuple`
         :param apply_fit: True if applied during fitting/training.
         :type apply_fit: `bool`
@@ -129,10 +127,8 @@ class GaussianAugmentation(Preprocessor):
         :type augmentation: `bool`
         :param ratio: Percentage of data augmentation. E.g. for a ratio of 1, the size of the dataset will double.
         :type ratio: `float`
-        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
-               maximum values allowed for features. If floats are provided, these will be used as the range of all
-               features. If arrays are provided, each value will be considered the bound for a feature, thus
-               the shape of clip values needs to match the total number of features.
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
         :type clip_values: `tuple`
         :param apply_fit: True if applied during fitting/training.
         :type apply_fit: `bool`

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -146,6 +146,7 @@ class GaussianAugmentation(Preprocessor):
                              " must be `False`.")
 
         if self.clip_values is not None:
+
             if len(self.clip_values) != 2:
                 raise ValueError('`clip_values` should be a tuple of 2 floats or arrays containing the allowed'
                                  'data range.')

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -33,9 +33,9 @@ class GaussianAugmentation(Preprocessor):
     as part of a :class:`.Classifier` instance, the defense will be applied automatically only when training if
     `augmentation` is true, and only when performing prediction otherwise.
     """
-    params = ['sigma', 'augmentation', 'ratio', '_apply_fit', '_apply_predict']
+    params = ['sigma', 'augmentation', 'ratio', 'clip_values', '_apply_fit', '_apply_predict']
 
-    def __init__(self, sigma=1.0, augmentation=True, ratio=1.0, apply_fit=True, apply_predict=False):
+    def __init__(self, sigma=1.0, augmentation=True, ratio=1.0, clip_values=None, apply_fit=True, apply_predict=False):
         """
         Initialize a Gaussian augmentation object.
 
@@ -47,11 +47,20 @@ class GaussianAugmentation(Preprocessor):
         :param ratio: Percentage of data augmentation. E.g. for a rate of 1, the size of the dataset will double.
                       If `augmentation` is false, `ratio` value is ignored.
         :type ratio: `float`
+        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
+               maximum values allowed for features. If floats are provided, these will be used as the range of all
+               features. If arrays are provided, each value will be considered the bound for a feature, thus
+               the shape of clip values needs to match the total number of features.
+        :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(GaussianAugmentation, self).__init__()
         self._is_fitted = True
-        self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio, _apply_fit=apply_fit,
-                        _apply_predict=apply_predict)
+        self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio, clip_values=clip_values,
+                        _apply_fit=apply_fit, _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
@@ -85,17 +94,20 @@ class GaussianAugmentation(Preprocessor):
             # Generate noisy samples
             x_aug = np.random.normal(x[indices], scale=self.sigma, size=(size,) + x.shape[1:])
             x_aug = np.vstack((x, x_aug))
-            logger.info('Augmented dataset size: %d', x_aug.shape[0])
-
             if y is not None:
-                return x_aug, np.concatenate((y, y[indices]))
+                y_aug = np.concatenate((y, y[indices]))
             else:
-                return x_aug, y
+                y_aug = y
+            logger.info('Augmented dataset size: %d', x_aug.shape[0])
         else:
             x_aug = np.random.normal(x, scale=self.sigma, size=x.shape)
+            y_aug = y
             logger.info('Created %i samples with Gaussian noise.')
 
-            return x_aug, y
+        if self.clip_values is not None:
+            x_aug = np.clip(x_aug, self.clip_values[0], self.clip_values[1])
+
+        return x_aug, y_aug
 
     def estimate_gradient(self, x, grad):
         return grad
@@ -117,11 +129,31 @@ class GaussianAugmentation(Preprocessor):
         :type augmentation: `bool`
         :param ratio: Percentage of data augmentation. E.g. for a ratio of 1, the size of the dataset will double.
         :type ratio: `float`
+        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
+               maximum values allowed for features. If floats are provided, these will be used as the range of all
+               features. If arrays are provided, each value will be considered the bound for a feature, thus
+               the shape of clip values needs to match the total number of features.
+        :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         # Save attack-specific parameters
         super(GaussianAugmentation, self).set_params(**kwargs)
 
         if self.augmentation and self.ratio <= 0:
             raise ValueError("The augmentation ratio must be positive.")
+
+        if self.augmentation and self.apply_fit and self.apply_predict:
+            raise ValueError("If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`"
+                             " must be `False`.")
+
+        if self.clip_values is not None:
+            if len(self.clip_values) != 2:
+                raise ValueError('`clip_values` should be a tuple of 2 floats or arrays containing the allowed'
+                                 'data range.')
+            if np.array(self.clip_values[0] >= self.clip_values[1]).any():
+                raise ValueError('Invalid `clip_values`: min >= max.')
 
         return True

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -70,9 +70,9 @@ class GaussianAugmentation(Preprocessor):
 
     def __call__(self, x, y=None):
         """
-        Augment the sample `(x, y)` with Gaussian noise. The result is either an extended dataset containing the original
-        sample, as well as the newly created noisy samples (augmentation=True) or just the noisy counterparts to the
-        original samples.
+        Augment the sample `(x, y)` with Gaussian noise. The result is either an extended dataset containing the
+        original sample, as well as the newly created noisy samples (augmentation=True) or just the noisy counterparts
+        to the original samples.
 
         :param x: Sample to augment with shape `(batch_size, width, height, depth)`.
         :type x: `np.ndarray`

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -57,7 +57,7 @@ class GaussianAugmentation(Preprocessor):
         """
         super(GaussianAugmentation, self).__init__()
         self._is_fitted = True
-        if self.augmentation and self.apply_fit and self.apply_predict:
+        if augmentation and apply_fit and apply_predict:
             raise ValueError("If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`"
                              " must be `False`.")
         self._apply_fit = apply_fit

--- a/art/defences/gaussian_augmentation.py
+++ b/art/defences/gaussian_augmentation.py
@@ -33,9 +33,9 @@ class GaussianAugmentation(Preprocessor):
     as part of a :class:`.Classifier` instance, the defense will be applied automatically only when training if
     `augmentation` is true, and only when performing prediction otherwise.
     """
-    params = ['sigma', 'augmentation', 'ratio']
+    params = ['sigma', 'augmentation', 'ratio', '_apply_fit', '_apply_predict']
 
-    def __init__(self, sigma=1., augmentation=True, ratio=1.):
+    def __init__(self, sigma=1.0, augmentation=True, ratio=1.0, apply_fit=True, apply_predict=False):
         """
         Initialize a Gaussian augmentation object.
 
@@ -50,15 +50,16 @@ class GaussianAugmentation(Preprocessor):
         """
         super(GaussianAugmentation, self).__init__()
         self._is_fitted = True
-        self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio)
+        self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio, _apply_fit=apply_fit,
+                        _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
-        return self.augmentation
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return not self.augmentation
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -177,7 +177,7 @@ class JpegCompression(Preprocessor):
 
         if len(self.clip_values) != 2:
             raise ValueError('`clip_values` should be a tuple of 2 floats or arrays containing the allowed'
-                                 'data range.')
+                             'data range.')
 
         if np.array(self.clip_values[0] >= self.clip_values[1]).any():
             raise ValueError('Invalid `clip_values`: min >= max.')

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -179,17 +179,17 @@ class JpegCompression(Preprocessor):
             logger.error('Data channel must be a positive integer. The batch dimension is not a valid channel.')
             raise ValueError('Data channel must be a positive integer. The batch dimension is not a valid channel.')
 
-        if self.clip_values is not None:
-            if len(self.clip_values) != 2:
-                raise ValueError('`clip_values` should be a tuple of 2 floats or arrays containing the allowed'
+        if len(self.clip_values) != 2:
+            raise ValueError('`clip_values` should be a tuple of 2 floats or arrays containing the allowed'
                                  'data range.')
-            if np.array(self.clip_values[0] >= self.clip_values[1]).any():
-                raise ValueError('Invalid `clip_values`: min >= max.')
 
-            if self.clip_values[0] != 0:
-                raise ValueError('`clip_values` min value should be 0.')
+        if np.array(self.clip_values[0] >= self.clip_values[1]).any():
+            raise ValueError('Invalid `clip_values`: min >= max.')
 
-            if self.clip_values[1] != 1.0 and self.clip_values[1] != 255:
-                raise ValueError('`clip_values` max value should be either 1 or 255.')
+        if self.clip_values[0] != 0:
+            raise ValueError('`clip_values` min value must be 0.')
+
+        if self.clip_values[1] != 1.0 and self.clip_values[1] != 255:
+            raise ValueError('`clip_values` max value must be either 1 or 255.')
 
         return True

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -85,11 +85,7 @@ class JpegCompression(Preprocessor):
             raise ValueError('Channel index does not match input shape.')
 
         if np.min(x) < 0.0:
-            raise ValueError('Negative values in input `x` detected. The JPEG compression defence required unnormalized'
-                             'input.')
-
-        if np.max(x) < 0.0:
-            raise ValueError('Negative values in input `x` detected. The JPEG compression defence required unnormalized'
+            raise ValueError('Negative values in input `x` detected. The JPEG compression defence requires unnormalized'
                              'input.')
 
         # Swap channel index

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -90,50 +90,50 @@ class JpegCompression(Preprocessor):
 
         # Swap channel index
         if self.channel_index < 3 and len(x.shape) == 4:
-            x_ = np.swapaxes(x, self.channel_index, 3)
+            x_local = np.swapaxes(x, self.channel_index, 3)
         else:
-            x_ = x.copy()
+            x_local = x.copy()
 
         # Convert into `uint8`
         if self.clip_values[1] == 1.0:
-            x_ = x_ * 255
-        x_ = x_.astype("uint8")
+            x_local = x_local * 255
+        x_local = x_local.astype("uint8")
 
         # Convert to 'L' mode
-        if x_.shape[-1] == 1:
-            x_ = np.reshape(x_, x_.shape[:-1])
+        if x_local.shape[-1] == 1:
+            x_local = np.reshape(x_local, x_local.shape[:-1])
 
         # Compress one image at a time
-        for i, xi in enumerate(x_):
-            if len(xi.shape) == 2:
-                xi = Image.fromarray(xi, mode='L')
-            elif xi.shape[-1] == 3:
-                xi = Image.fromarray(xi, mode='RGB')
+        for i, x_i in enumerate(x_local):
+            if len(x_i.shape) == 2:
+                x_i = Image.fromarray(x_i, mode='L')
+            elif x_i.shape[-1] == 3:
+                x_i = Image.fromarray(x_i, mode='RGB')
             else:
                 logger.log(level=40, msg="Currently only support `RGB` and `L` images.")
                 raise NotImplementedError("Currently only support `RGB` and `L` images.")
 
             out = BytesIO()
-            xi.save(out, format="jpeg", quality=self.quality)
-            xi = Image.open(out)
-            xi = np.array(xi)
-            x_[i] = xi
+            x_i.save(out, format="jpeg", quality=self.quality)
+            x_i = Image.open(out)
+            x_i = np.array(x_i)
+            x_local[i] = x_i
             del out
 
         # Expand dim if black/white images
-        if len(x_.shape) < 4:
-            x_ = np.expand_dims(x_, 3)
+        if len(x_local.shape) < 4:
+            x_local = np.expand_dims(x_local, 3)
 
         # Convert to old dtype
         if self.clip_values[1] == 1.0:
-            x_ = x_ / 255.0
-        x_ = x_.astype(NUMPY_DTYPE)
+            x_local = x_local / 255.0
+        x_local = x_local.astype(NUMPY_DTYPE)
 
         # Swap channel index
         if self.channel_index < 3:
-            x_ = np.swapaxes(x_, self.channel_index, 3)
+            x_local = np.swapaxes(x_local, self.channel_index, 3)
 
-        return x_, y
+        return x_local, y
 
     def estimate_gradient(self, x, grad):
         return grad

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -34,9 +34,9 @@ class JpegCompression(Preprocessor):
     Implement the jpeg compression defence approach. Some related papers: https://arxiv.org/pdf/1705.02900.pdf,
     https://arxiv.org/abs/1608.00853
     """
-    params = ['quality', 'channel_index', 'clip_values']
+    params = ['quality', 'channel_index', 'clip_values', '_apply_fit', '_apply_predict']
 
-    def __init__(self, clip_values, quality=50, channel_index=3):
+    def __init__(self, clip_values, quality=50, channel_index=3, apply_fit=True, apply_predict=False):
         """
         Create an instance of jpeg compression.
 
@@ -44,18 +44,23 @@ class JpegCompression(Preprocessor):
         :type quality: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(JpegCompression, self).__init__()
         self._is_fitted = True
-        self.set_params(quality=quality, channel_index=channel_index, clip_values=clip_values)
+        self.set_params(quality=quality, channel_index=channel_index, clip_values=clip_values, _apply_fit=apply_fit,
+                        _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
-        return False
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return True
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -34,7 +34,7 @@ class JpegCompression(Preprocessor):
     Implement the jpeg compression defence approach. Some related papers: https://arxiv.org/pdf/1705.02900.pdf,
     https://arxiv.org/abs/1608.00853
     """
-    params = ['quality', 'channel_index', 'clip_values', '_apply_fit', '_apply_predict']
+    params = ['quality', 'channel_index', 'clip_values']
 
     def __init__(self, clip_values, quality=50, channel_index=3, apply_fit=True, apply_predict=False):
         """
@@ -54,8 +54,9 @@ class JpegCompression(Preprocessor):
         """
         super(JpegCompression, self).__init__()
         self._is_fitted = True
-        self.set_params(quality=quality, channel_index=channel_index, clip_values=clip_values, _apply_fit=apply_fit,
-                        _apply_predict=apply_predict)
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(quality=quality, channel_index=channel_index, clip_values=clip_values)
 
     @property
     def apply_fit(self):
@@ -155,10 +156,6 @@ class JpegCompression(Preprocessor):
         :type quality: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
-        :param apply_fit: True if applied during fitting/training.
-        :type apply_fit: `bool`
-        :param apply_predict: True if applied during predicting.
-        :type apply_predict: `bool`
         """
         # Save defense-specific parameters
         super(JpegCompression, self).set_params(**kwargs)

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -40,10 +40,8 @@ class JpegCompression(Preprocessor):
         """
         Create an instance of jpeg compression.
 
-        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
-               maximum values allowed for features. If floats are provided, these will be used as the range of all
-               features. If arrays are provided, each value will be considered the bound for a feature, thus
-               the shape of clip values needs to match the total number of features.
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
         :type clip_values: `tuple`
         :param quality: The image quality, on a scale from 1 (worst) to 95 (best). Values above 95 should be avoided.
         :type quality: `int`
@@ -154,10 +152,8 @@ class JpegCompression(Preprocessor):
         """
         Take in a dictionary of parameters and applies defence-specific checks before saving them as attributes.
 
-        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
-               maximum values allowed for features. If floats are provided, these will be used as the range of all
-               features. If arrays are provided, each value will be considered the bound for a feature, thus
-               the shape of clip values needs to match the total number of features.
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
         :type clip_values: `tuple`
         :param quality: The image quality, on a scale from 1 (worst) to 95 (best). Values above 95 should be avoided.
         :type quality: `int`

--- a/art/defences/jpeg_compression.py
+++ b/art/defences/jpeg_compression.py
@@ -40,6 +40,11 @@ class JpegCompression(Preprocessor):
         """
         Create an instance of jpeg compression.
 
+        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
+               maximum values allowed for features. If floats are provided, these will be used as the range of all
+               features. If arrays are provided, each value will be considered the bound for a feature, thus
+               the shape of clip values needs to match the total number of features.
+        :type clip_values: `tuple`
         :param quality: The image quality, on a scale from 1 (worst) to 95 (best). Values above 95 should be avoided.
         :type quality: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
@@ -149,10 +154,19 @@ class JpegCompression(Preprocessor):
         """
         Take in a dictionary of parameters and applies defence-specific checks before saving them as attributes.
 
+        :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
+               maximum values allowed for features. If floats are provided, these will be used as the range of all
+               features. If arrays are provided, each value will be considered the bound for a feature, thus
+               the shape of clip values needs to match the total number of features.
+        :type clip_values: `tuple`
         :param quality: The image quality, on a scale from 1 (worst) to 95 (best). Values above 95 should be avoided.
         :type quality: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         # Save defense-specific parameters
         super(JpegCompression, self).set_params(**kwargs)

--- a/art/defences/label_smoothing.py
+++ b/art/defences/label_smoothing.py
@@ -32,24 +32,30 @@ class LabelSmoothing(Preprocessor):
     """
     params = ['max_value']
 
-    def __init__(self, max_value=.9):
+    def __init__(self, max_value=0.9, apply_fit=True, apply_predict=False):
         """
         Create an instance of label smoothing.
 
         :param max_value: Value to affect to correct label
         :type max_value: `float`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(LabelSmoothing, self).__init__()
         self._is_fitted = True
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
         self.set_params(max_value=max_value)
 
     @property
     def apply_fit(self):
-        return True
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return False
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """

--- a/art/defences/pixel_defend.py
+++ b/art/defences/pixel_defend.py
@@ -32,12 +32,15 @@ class PixelDefend(Preprocessor):
     Implement the pixel defence approach. Defense based on PixelCNN that projects samples back to the data manifold.
     Paper link: https://arxiv.org/abs/1710.10766
     """
-    params = ['eps', 'pixel_cnn']
+    params = ['clip_values', 'eps', 'pixel_cnn']
 
-    def __init__(self, eps=16, pixel_cnn=None):
+    def __init__(self, clip_values=(0, 1), eps=16, pixel_cnn=None, apply_fit=False, apply_predict=True):
         """
         Create an instance of pixel defence.
 
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
+        :type clip_values: `tuple`
         :param eps: Defense parameter 0-255.
         :type eps: `int`
         :param pixel_cnn: Pre-trained PixelCNN model.
@@ -45,18 +48,20 @@ class PixelDefend(Preprocessor):
         """
         super(PixelDefend, self).__init__()
         self._is_fitted = True
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
         if pixel_cnn is not None:
-            self.set_params(eps=eps, pixel_cnn=pixel_cnn)
+            self.set_params(clip_values=clip_values, eps=eps, pixel_cnn=pixel_cnn)
         else:
-            self.set_params(eps=eps)
+            self.set_params(clip_values=clip_values, eps=eps)
 
     @property
     def apply_fit(self):
-        return False
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return True
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """
@@ -103,9 +108,8 @@ class PixelDefend(Preprocessor):
         x_ = x_ / 255.0
         x_ = x_.astype(NUMPY_DTYPE).reshape(original_shape)
 
-        # Clip values into the range [0, 1]
-        clip_values = (0, 1)
-        x_ = np.clip(x_, clip_values[0], clip_values[1])
+        # Clip to clip_values
+        x_ = np.clip(x_, self.clip_values[0], self.clip_values[1])
 
         return x_, y
 
@@ -123,6 +127,9 @@ class PixelDefend(Preprocessor):
         Take in a dictionary of parameters and applies defence-specific checks before saving them as attributes.
 
         Defense-specific parameters:
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
+        :type clip_values: `tuple`
         :param eps: Defense parameter 0-255.
         :type eps: `int`
         :param pixel_cnn: Pre-trained PixelCNN model.
@@ -138,5 +145,14 @@ class PixelDefend(Preprocessor):
 
         if hasattr(self, 'pixel_cnn') and not isinstance(self.pixel_cnn, Classifier):
             raise TypeError("PixelCNN model must be of type Classifier.")
+
+        if np.array(self.clip_values[0] >= self.clip_values[1]).any():
+            raise ValueError('Invalid `clip_values`: min >= max.')
+
+        if self.clip_values[0] != 0:
+            raise ValueError('`clip_values` min value must be 0.')
+
+        if self.clip_values[1] != 1:
+            raise ValueError('`clip_values` max value must be 1.')
 
         return True

--- a/art/defences/spatial_smoothing.py
+++ b/art/defences/spatial_smoothing.py
@@ -32,7 +32,7 @@ class SpatialSmoothing(Preprocessor):
     """
     Implement the local spatial smoothing defence approach. Defence method from https://arxiv.org/abs/1704.01155.
     """
-    params = ['window_size', 'channel_index', 'clip_values', '_apply_fit', '_apply_predict']
+    params = ['window_size', 'channel_index', 'clip_values']
 
     def __init__(self, window_size=3, channel_index=3, clip_values=None, apply_fit=False, apply_predict=True):
         """
@@ -52,8 +52,9 @@ class SpatialSmoothing(Preprocessor):
         """
         super(SpatialSmoothing, self).__init__()
         self._is_fitted = True
-        self.set_params(channel_index=channel_index, window_size=window_size, clip_values=clip_values,
-                        _apply_fit=apply_fit, _apply_predict=apply_predict)
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(channel_index=channel_index, window_size=window_size, clip_values=clip_values)
 
     @property
     def apply_fit(self):
@@ -110,10 +111,6 @@ class SpatialSmoothing(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
-        :param apply_fit: True if applied during fitting/training.
-        :type apply_fit: `bool`
-        :param apply_predict: True if applied during predicting.
-        :type apply_predict: `bool`
         """
         # Save attack-specific parameters
         super(SpatialSmoothing, self).set_params(**kwargs)

--- a/art/defences/spatial_smoothing.py
+++ b/art/defences/spatial_smoothing.py
@@ -129,8 +129,10 @@ class SpatialSmoothing(Preprocessor):
                              'valid channel.')
 
         if self.clip_values is not None:
+
             if len(self.clip_values) != 2:
                 raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
+
             if np.array(self.clip_values[0] >= self.clip_values[1]).any():
                 raise ValueError('Invalid `clip_values`: min >= max.')
 

--- a/art/defences/spatial_smoothing.py
+++ b/art/defences/spatial_smoothing.py
@@ -32,9 +32,9 @@ class SpatialSmoothing(Preprocessor):
     """
     Implement the local spatial smoothing defence approach. Defence method from https://arxiv.org/abs/1704.01155.
     """
-    params = ['channel_index', 'window_size', 'clip_values', '_apply_fit', '_apply_predict']
+    params = ['window_size', 'channel_index', 'clip_values', '_apply_fit', '_apply_predict']
 
-    def __init__(self, channel_index, window_size=3, clip_values=None, apply_fit=False, apply_predict=True):
+    def __init__(self, window_size=3, channel_index=3, clip_values=None, apply_fit=False, apply_predict=True):
         """
         Create an instance of local spatial smoothing.
 
@@ -45,6 +45,10 @@ class SpatialSmoothing(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(SpatialSmoothing, self).__init__()
         self._is_fitted = True
@@ -81,7 +85,7 @@ class SpatialSmoothing(Preprocessor):
         size = tuple(size)
 
         result = ndimage.filters.median_filter(x, size=size, mode="reflect")
-        if hasattr(self, 'clip_values') and self.clip_values is not None:
+        if self.clip_values is not None:
             np.clip(result, self.clip_values[0], self.clip_values[1], out=result)
 
         return result.astype(NUMPY_DTYPE), y
@@ -106,6 +110,10 @@ class SpatialSmoothing(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         # Save attack-specific parameters
         super(SpatialSmoothing, self).set_params(**kwargs)

--- a/art/defences/spatial_smoothing.py
+++ b/art/defences/spatial_smoothing.py
@@ -32,7 +32,7 @@ class SpatialSmoothing(Preprocessor):
     """
     Implement the local spatial smoothing defence approach. Defence method from https://arxiv.org/abs/1704.01155.
     """
-    params = ['channel_index', 'window_size', 'clip_values', '_apply_fit', '_predict']
+    params = ['channel_index', 'window_size', 'clip_values', '_apply_fit', '_apply_predict']
 
     def __init__(self, channel_index, window_size=3, clip_values=None, apply_fit=False, apply_predict=True):
         """

--- a/art/defences/spatial_smoothing.py
+++ b/art/defences/spatial_smoothing.py
@@ -32,31 +32,32 @@ class SpatialSmoothing(Preprocessor):
     """
     Implement the local spatial smoothing defence approach. Defence method from https://arxiv.org/abs/1704.01155.
     """
-    params = ['window_size', 'channel_index', 'clip_values']
+    params = ['channel_index', 'window_size', 'clip_values', '_apply_fit', '_predict']
 
-    def __init__(self, window_size=3, channel_index=3, clip_values=None):
+    def __init__(self, channel_index, window_size=3, clip_values=None, apply_fit=False, apply_predict=True):
         """
         Create an instance of local spatial smoothing.
 
-        :param window_size: The size of the sliding window.
-        :type window_size: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param window_size: The size of the sliding window.
+        :type window_size: `int`
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
         """
         super(SpatialSmoothing, self).__init__()
         self._is_fitted = True
-        self.set_params(window_size=window_size, channel_index=channel_index, clip_values=clip_values)
+        self.set_params(channel_index=channel_index, window_size=window_size, clip_values=clip_values,
+                        _apply_fit=apply_fit, _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
-        return False
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return True
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """

--- a/art/defences/thermometer_encoding.py
+++ b/art/defences/thermometer_encoding.py
@@ -32,7 +32,7 @@ class ThermometerEncoding(Preprocessor):
     """
     Implement the thermometer encoding defence approach. Defence method from https://openreview.net/forum?id=S18Su--CW.
     """
-    params = ['clip_values', 'num_space', 'channel_index', '_apply_fit', '_apply_predict']
+    params = ['clip_values', 'num_space', 'channel_index']
 
     def __init__(self, clip_values, num_space=10, channel_index=3, apply_fit=True, apply_predict=True):
         """
@@ -52,8 +52,9 @@ class ThermometerEncoding(Preprocessor):
         """
         super(ThermometerEncoding, self).__init__()
         self._is_fitted = True
-        self.set_params(clip_values=clip_values, num_space=num_space, channel_index=channel_index, _apply_fit=apply_fit,
-                        _apply_predict=apply_predict)
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(clip_values=clip_values, num_space=num_space, channel_index=channel_index)
 
     @property
     def apply_fit(self):
@@ -137,10 +138,6 @@ class ThermometerEncoding(Preprocessor):
         :type num_space: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
-        :param apply_fit: True if applied during fitting/training.
-        :type apply_fit: `bool`
-        :param apply_predict: True if applied during predicting.
-        :type apply_predict: `bool`
         """
         # Save attack-specific parameters
         super(ThermometerEncoding, self).set_params(**kwargs)

--- a/art/defences/thermometer_encoding.py
+++ b/art/defences/thermometer_encoding.py
@@ -32,31 +32,36 @@ class ThermometerEncoding(Preprocessor):
     """
     Implement the thermometer encoding defence approach. Defence method from https://openreview.net/forum?id=S18Su--CW.
     """
-    params = ['num_space', 'channel_index', 'clip_values']
+    params = ['clip_values', 'num_space', 'channel_index', '_apply_fit', '_apply_predict']
 
-    def __init__(self, num_space=10, channel_index=3, clip_values=None):
+    def __init__(self, clip_values, num_space=10, channel_index=3, apply_fit=True, apply_predict=True):
         """
         Create an instance of thermometer encoding.
 
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
+        :type clip_values: `tuple`
         :param num_space: Number of evenly spaced levels within [0, 1].
         :type num_space: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
-        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
-               for features.
-        :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(ThermometerEncoding, self).__init__()
         self._is_fitted = True
-        self.set_params(num_space=num_space, channel_index=channel_index, clip_values=clip_values)
+        self.set_params(clip_values=clip_values, num_space=num_space, channel_index=channel_index, _apply_fit=apply_fit,
+                        _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
-        return True
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return True
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """
@@ -71,8 +76,7 @@ class ThermometerEncoding(Preprocessor):
         """
         result = np.apply_along_axis(self._perchannel, self.channel_index, x)
 
-        # result = np.concatenate(result, axis=self.channel_index)
-        if hasattr(self, 'clip_values') and self.clip_values is not None:
+        if self.clip_values is not None:
             np.clip(result, self.clip_values[0], self.clip_values[1], out=result)
 
         return result.astype(NUMPY_DTYPE), y
@@ -129,13 +133,17 @@ class ThermometerEncoding(Preprocessor):
         """
         Take in a dictionary of parameters and applies defence-specific checks before saving them as attributes.
 
+        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
+               for features.
+        :type clip_values: `tuple`
         :param num_space: Number of evenly spaced levels within [0, 1].
         :type num_space: `int`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
-        :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
-               for features.
-        :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         # Save attack-specific parameters
         super(ThermometerEncoding, self).set_params(**kwargs)
@@ -144,10 +152,13 @@ class ThermometerEncoding(Preprocessor):
             logger.error('Number of evenly spaced levels must be a positive integer.')
             raise ValueError('Number of evenly spaced levels must be a positive integer.')
 
-        if hasattr(self, 'clip_values') and self.clip_values is not None:
-            if len(self.clip_values) != 2:
-                raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
-            if np.array(self.clip_values[0] >= self.clip_values[1]).any():
-                raise ValueError('Invalid `clip_values`: min >= max.')
+        if len(self.clip_values) != 2:
+            raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
+
+        if self.clip_values[0] != 0:
+            raise ValueError('`clip_values` min value must be 0.')
+
+        if self.clip_values[1] != 1:
+            raise ValueError('`clip_values` max value must be 1.')
 
         return True

--- a/art/defences/thermometer_encoding.py
+++ b/art/defences/thermometer_encoding.py
@@ -75,10 +75,7 @@ class ThermometerEncoding(Preprocessor):
         :rtype: `np.ndarray`
         """
         result = np.apply_along_axis(self._perchannel, self.channel_index, x)
-
-        if self.clip_values is not None:
-            np.clip(result, self.clip_values[0], self.clip_values[1], out=result)
-
+        np.clip(result, self.clip_values[0], self.clip_values[1], out=result)
         return result.astype(NUMPY_DTYPE), y
 
     def _perchannel(self, x):

--- a/art/defences/variance_minimization.py
+++ b/art/defences/variance_minimization.py
@@ -35,7 +35,7 @@ class TotalVarMin(Preprocessor):
     """
     params = ['prob', 'norm', 'lamb', 'solver', 'max_iter', 'clip_values']
 
-    def __init__(self, prob=0.3, norm=2, lamb=0.5, solver='L-BFGS-B', max_iter=10, clip_values=(0, 1)):
+    def __init__(self, prob=0.3, norm=2, lamb=0.5, solver='L-BFGS-B', max_iter=10, clip_values=None):
         """
         Create an instance of total variance minimization.
 
@@ -87,7 +87,7 @@ class TotalVarMin(Preprocessor):
             mask = (np.random.rand(*xi.shape) < self.prob).astype('int')
             x_preproc[i] = self._minimize(xi, mask)
 
-        if hasattr(self, 'clip_values') and self.clip_values is not None:
+        if self.clip_values is not None:
             np.clip(x_preproc, self.clip_values[0], self.clip_values[1], out=x_preproc)
 
         return x_preproc.astype(NUMPY_DTYPE), y
@@ -233,9 +233,11 @@ class TotalVarMin(Preprocessor):
             logger.error('Number of iterations must be a positive integer.')
             raise ValueError('Number of iterations must be a positive integer.')
 
-        if len(self.clip_values) != 2:
-            raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
-        if np.array(self.clip_values[0] >= self.clip_values[1]).any():
-            raise ValueError('Invalid `clip_values`: min >= max.')
+        if self.clip_values is not None:
+            if len(self.clip_values) != 2:
+                raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
+
+            if np.array(self.clip_values[0] >= self.clip_values[1]).any():
+                raise ValueError('Invalid `clip_values`: min >= max.')
 
         return True

--- a/art/defences/variance_minimization.py
+++ b/art/defences/variance_minimization.py
@@ -33,9 +33,10 @@ class TotalVarMin(Preprocessor):
     Implement the total variance minimization defence approach. Defence method from [Guo et al., 2018].
     Paper link: https://openreview.net/forum?id=SyJ7ClWCb
     """
-    params = ['prob', 'norm', 'lamb', 'solver', 'max_iter', 'clip_values']
+    params = ['prob', 'norm', 'lamb', 'solver', 'max_iter', 'clip_values', '_apply_fit', '_apply_predict']
 
-    def __init__(self, prob=0.3, norm=2, lamb=0.5, solver='L-BFGS-B', max_iter=10, clip_values=None):
+    def __init__(self, prob=0.3, norm=2, lamb=0.5, solver='L-BFGS-B', max_iter=10, clip_values=None, apply_fit=False,
+                 apply_predict=True):
         """
         Create an instance of total variance minimization.
 
@@ -52,18 +53,23 @@ class TotalVarMin(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         super(TotalVarMin, self).__init__()
         self._is_fitted = True
-        self.set_params(prob=prob, norm=norm, lamb=lamb, solver=solver, max_iter=max_iter, clip_values=clip_values)
+        self.set_params(prob=prob, norm=norm, lamb=lamb, solver=solver, max_iter=max_iter, clip_values=clip_values,
+                        _apply_fit=apply_fit, _apply_predict=apply_predict)
 
     @property
     def apply_fit(self):
-        return False
+        return self._apply_fit
 
     @property
     def apply_predict(self):
-        return True
+        return self._apply_predict
 
     def __call__(self, x, y=None):
         """
@@ -213,6 +219,10 @@ class TotalVarMin(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
         """
         # Save defence-specific parameters
         super(TotalVarMin, self).set_params(**kwargs)

--- a/art/defences/variance_minimization.py
+++ b/art/defences/variance_minimization.py
@@ -244,6 +244,7 @@ class TotalVarMin(Preprocessor):
             raise ValueError('Number of iterations must be a positive integer.')
 
         if self.clip_values is not None:
+
             if len(self.clip_values) != 2:
                 raise ValueError('`clip_values` should be a tuple of 2 floats containing the allowed data range.')
 

--- a/art/defences/variance_minimization.py
+++ b/art/defences/variance_minimization.py
@@ -89,9 +89,9 @@ class TotalVarMin(Preprocessor):
         x_preproc = x.copy()
 
         # Minimize one input at a time
-        for i, xi in enumerate(x_preproc):
-            mask = (np.random.rand(*xi.shape) < self.prob).astype('int')
-            x_preproc[i] = self._minimize(xi, mask)
+        for i, x_i in enumerate(x_preproc):
+            mask = (np.random.rand(*x_i.shape) < self.prob).astype('int')
+            x_preproc[i] = self._minimize(x_i, mask)
 
         if self.clip_values is not None:
             np.clip(x_preproc, self.clip_values[0], self.clip_values[1], out=x_preproc)

--- a/art/defences/variance_minimization.py
+++ b/art/defences/variance_minimization.py
@@ -33,7 +33,7 @@ class TotalVarMin(Preprocessor):
     Implement the total variance minimization defence approach. Defence method from [Guo et al., 2018].
     Paper link: https://openreview.net/forum?id=SyJ7ClWCb
     """
-    params = ['prob', 'norm', 'lamb', 'solver', 'max_iter', 'clip_values', '_apply_fit', '_apply_predict']
+    params = ['prob', 'norm', 'lamb', 'solver', 'max_iter', 'clip_values']
 
     def __init__(self, prob=0.3, norm=2, lamb=0.5, solver='L-BFGS-B', max_iter=10, clip_values=None, apply_fit=False,
                  apply_predict=True):
@@ -60,8 +60,9 @@ class TotalVarMin(Preprocessor):
         """
         super(TotalVarMin, self).__init__()
         self._is_fitted = True
-        self.set_params(prob=prob, norm=norm, lamb=lamb, solver=solver, max_iter=max_iter, clip_values=clip_values,
-                        _apply_fit=apply_fit, _apply_predict=apply_predict)
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(prob=prob, norm=norm, lamb=lamb, solver=solver, max_iter=max_iter, clip_values=clip_values)
 
     @property
     def apply_fit(self):
@@ -219,10 +220,6 @@ class TotalVarMin(Preprocessor):
         :param clip_values: Tuple of the form `(min, max)` representing the minimum and maximum values allowed
                for features.
         :type clip_values: `tuple`
-        :param apply_fit: True if applied during fitting/training.
-        :type apply_fit: `bool`
-        :param apply_predict: True if applied during predicting.
-        :type apply_predict: `bool`
         """
         # Save defence-specific parameters
         super(TotalVarMin, self).set_params(**kwargs)

--- a/art/wrappers/query_efficient_bb.py
+++ b/art/wrappers/query_efficient_bb.py
@@ -100,7 +100,7 @@ class QueryEfficientBBGradientEstimation(ClassifierWrapper):
                 (new_y_plus - new_y_minus).reshape(self.num_basis, -1) /
                 (2 * self.sigma)).reshape([-1] + list(self.input_shape)), axis=0)
             grads.append(query_efficient_grad)
-        grads = self._apply_processing_gradient(np.array(grads))
+        grads = self._apply_preprocessing_normalization_gradient(np.array(grads))
         return grads
 
     def _wrap_predict(self, x, logits=False, batch_size=128):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
+exit_code=0
 python -m unittest discover tests/attacks -p 'test_*.py'
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest discover tests/classifiers -p 'test_*.py'
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest discover tests/defences -p 'test_*.py'
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest discover tests/detection -p 'test_*.py'
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest discover tests/poison_detection -p 'test_*.py'
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest discover tests/wrappers -p 'test_*.py'
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest tests.test_data_generators
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest tests.test_metrics
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest tests.test_utils
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
 python -m unittest tests.test_visualization
+if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+exit $exit_code

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 exit_code=0
 python -m unittest discover tests/attacks -p 'test_*.py'
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest discover tests/classifiers -p 'test_*.py'
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest discover tests/defences -p 'test_*.py'
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest discover tests/detection -p 'test_*.py'
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest discover tests/poison_detection -p 'test_*.py'
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest discover tests/wrappers -p 'test_*.py'
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest tests.test_data_generators
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest tests.test_metrics
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest tests.test_utils
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 python -m unittest tests.test_visualization
-if [[ $? -ne 0 ]]; then echo exit_code=1; fi
+if [[ $? -ne 0 ]]; then exit_code=1; fi
 exit $exit_code

--- a/tests/attacks/test_boundary.py
+++ b/tests/attacks/test_boundary.py
@@ -39,6 +39,7 @@ class TestBoundary(unittest.TestCase):
     """
     A unittest class for testing the Boundary attack.
     """
+
     @classmethod
     def setUpClass(cls):
         # Get MNIST

--- a/tests/attacks/test_iterative_method.py
+++ b/tests/attacks/test_iterative_method.py
@@ -107,26 +107,6 @@ class TestIterativeAttack(unittest.TestCase):
         acc = np.sum(np.argmax(test_y_pred, axis=1) == np.argmax(y_test, axis=1)) / y_test.shape[0]
         logger.info('Accuracy on adversarial test examples: %.2f%%', (acc * 100))
 
-        # Test BIM with 3 random initialisations
-        attack = BasicIterativeMethod(classifier, num_random_init=3)
-        x_train_adv = attack.generate(x_train)
-        x_test_adv = attack.generate(x_test)
-
-        self.assertFalse((x_train == x_train_adv).all())
-        self.assertFalse((x_test == x_test_adv).all())
-
-        train_y_pred = get_labels_np_array(classifier.predict(x_train_adv))
-        test_y_pred = get_labels_np_array(classifier.predict(x_test_adv))
-
-        self.assertFalse((y_train == train_y_pred).all())
-        self.assertFalse((y_test == test_y_pred).all())
-
-        acc = np.sum(np.argmax(train_y_pred, axis=1) == np.argmax(y_train, axis=1)) / y_train.shape[0]
-        logger.info('Accuracy on adversarial train examples with 3 random initializations: %.2f%%', (acc * 100))
-
-        acc = np.sum(np.argmax(test_y_pred, axis=1) == np.argmax(y_test, axis=1)) / y_test.shape[0]
-        logger.info('Accuracy on adversarial test examples with 3 random initializations: %.2f%%', (acc * 100))
-
     def _test_mnist_targeted(self, classifier):
         # Get MNIST
         (_, _), (x_test, _) = self.mnist

--- a/tests/attacks/test_saliency_map.py
+++ b/tests/attacks/test_saliency_map.py
@@ -219,6 +219,5 @@ class TestSaliencyMapVectors(unittest.TestCase):
         logger.info('Accuracy on Iris with JSMA adversarial examples: %.2f%%', (acc * 100))
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -45,11 +45,11 @@ class TestClassifier(unittest.TestCase):
         # Set master seed
         master_seed(1234)
 
-    def test_processing(self):
+    def test_preprocessing_normalisation(self):
         classifier = ClassifierInstance((0, 1))
 
         x = np.random.rand(100, 200)
-        new_x = classifier._apply_processing(x)
+        new_x = classifier._apply_preprocessing_normalization(x)
         self.assertTrue(np.sum(x - new_x) == 0)
 
     def test_repr(self):

--- a/tests/classifiers/test_detector_classifier.py
+++ b/tests/classifiers/test_detector_classifier.py
@@ -15,7 +15,6 @@ from art.utils import load_mnist, master_seed
 
 logger = logging.getLogger('testLogger')
 
-
 NB_TRAIN = 1000
 NB_TEST = 2
 
@@ -47,6 +46,7 @@ class TestDetectorClassifier(unittest.TestCase):
     """
     This class tests the functionalities of the DetectorClassifier.
     """
+
     @classmethod
     def setUpClass(cls):
         # Get MNIST

--- a/tests/classifiers/test_keras.py
+++ b/tests/classifiers/test_keras.py
@@ -179,16 +179,19 @@ class TestKerasClassifier(unittest.TestCase):
 
         (_, _), (x_test, y_test) = self.mnist
 
-        fs = FeatureSqueezing(bit_depth=2)
-        jpeg = JpegCompression()
+        clip_values = (0, 1)
+        fs = FeatureSqueezing(clip_values=clip_values, bit_depth=2)
+        jpeg = JpegCompression(clip_values=clip_values, apply_predict=True)
         smooth = SpatialSmoothing()
-        classifier = KerasClassifier(clip_values=(0, 1), model=self.model_mnist._model, defences=[fs, jpeg, smooth])
+        classifier = KerasClassifier(clip_values=clip_values, model=self.model_mnist._model,
+                                     defences=[fs, jpeg, smooth])
         self.assertTrue(len(classifier.defences) == 3)
 
         preds_classifier = classifier.predict(x_test)
 
         # Apply the same defences by hand
-        x_test_defense, _ = fs(x_test, y_test)
+        x_test_defense = x_test
+        x_test_defense, _ = fs(x_test_defense, y_test)
         x_test_defense, _ = jpeg(x_test_defense, y_test)
         x_test_defense, _ = smooth(x_test_defense, y_test)
         preds_check = self.model_mnist._model.predict(x_test_defense)

--- a/tests/classifiers/test_pytorch.py
+++ b/tests/classifiers/test_pytorch.py
@@ -240,7 +240,7 @@ class TestPyTorchClassifier(unittest.TestCase):
             loaded = pickle.load(f)
             self.assertTrue(self.module_classifier._clip_values == loaded._clip_values)
             self.assertTrue(self.module_classifier._channel_index == loaded._channel_index)
-            self.assertTrue(self.module_classifier.__dict__.keys() == loaded.__dict__.keys())
+            self.assertTrue(set(self.module_classifier.__dict__.keys()) == set(loaded.__dict__.keys()))
 
         # Get MNIST
         (_, _), (x_test, y_test) = self.mnist

--- a/tests/classifiers/test_pytorch.py
+++ b/tests/classifiers/test_pytorch.py
@@ -13,7 +13,6 @@ from art.utils import load_mnist, master_seed
 
 logger = logging.getLogger('testLogger')
 
-
 NB_TRAIN = 1000
 NB_TEST = 20
 
@@ -45,6 +44,7 @@ class TestPyTorchClassifier(unittest.TestCase):
     """
     This class tests the functionalities of the PyTorch-based classifier.
     """
+
     @classmethod
     def setUpClass(cls):
         # Get MNIST
@@ -184,7 +184,7 @@ class TestPyTorchClassifier(unittest.TestCase):
         for i, name in enumerate(layer_names):
             act_i = ptc.get_activations(x_test, i, batch_size=5)
             act_name = ptc.get_activations(x_test, name, batch_size=5)
-            self.assertTrue(np.sum(act_name-act_i) == 0)
+            self.assertTrue(np.sum(act_name - act_i) == 0)
 
         self.assertTrue(ptc.get_activations(x_test, 0, batch_size=5).shape == (20, 16, 24, 24))
         self.assertTrue(ptc.get_activations(x_test, 1, batch_size=5).shape == (20, 16, 24, 24))
@@ -237,10 +237,10 @@ class TestPyTorchClassifier(unittest.TestCase):
 
         # Unpickle:
         with open(full_path, 'rb') as f:
-             loaded = pickle.load(f)
-             self.assertTrue(self.module_classifier._clip_values == loaded._clip_values)
-             self.assertTrue(self.module_classifier._channel_index == loaded._channel_index)
-             self.assertTrue(self.module_classifier.__dict__.keys() == loaded.__dict__.keys())
+            loaded = pickle.load(f)
+            self.assertTrue(self.module_classifier._clip_values == loaded._clip_values)
+            self.assertTrue(self.module_classifier._channel_index == loaded._channel_index)
+            self.assertTrue(self.module_classifier.__dict__.keys() == loaded.__dict__.keys())
 
         # Get MNIST
         (_, _), (x_test, y_test) = self.mnist
@@ -255,4 +255,3 @@ class TestPyTorchClassifier(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/classifiers/test_tensorflow.py
+++ b/tests/classifiers/test_tensorflow.py
@@ -187,7 +187,7 @@ class TestTFClassifier(unittest.TestCase):
             loaded = pickle.load(f)
             self.assertTrue(self.classifier._clip_values == loaded._clip_values)
             self.assertTrue(self.classifier._channel_index == loaded._channel_index)
-            self.assertTrue(self.classifier.__dict__.keys() == loaded.__dict__.keys())
+            self.assertTrue(set(self.classifier.__dict__.keys()) == set(loaded.__dict__.keys()))
 
         # Test predict
         preds1 = self.classifier.predict(x_test)

--- a/tests/classifiers/test_tensorflow.py
+++ b/tests/classifiers/test_tensorflow.py
@@ -10,7 +10,6 @@ from art.utils import get_classifier_tf, load_mnist, master_seed
 
 logger = logging.getLogger('testLogger')
 
-
 NB_TRAIN = 1000
 NB_TEST = 20
 
@@ -19,6 +18,7 @@ class TestTFClassifier(unittest.TestCase):
     """
     This class tests the functionalities of the Tensorflow-based classifier.
     """
+
     @classmethod
     def setUpClass(cls):
         # Get MNIST
@@ -184,10 +184,10 @@ class TestTFClassifier(unittest.TestCase):
 
         # Unpickle:
         with open(full_path, 'rb') as f:
-             loaded = pickle.load(f)
-             self.assertTrue(self.classifier._clip_values == loaded._clip_values)
-             self.assertTrue(self.classifier._channel_index == loaded._channel_index)
-             self.assertTrue(self.classifier.__dict__.keys() == loaded.__dict__.keys())
+            loaded = pickle.load(f)
+            self.assertTrue(self.classifier._clip_values == loaded._clip_values)
+            self.assertTrue(self.classifier._channel_index == loaded._channel_index)
+            self.assertTrue(self.classifier.__dict__.keys() == loaded.__dict__.keys())
 
         # Test predict
         preds1 = self.classifier.predict(x_test)
@@ -201,4 +201,3 @@ class TestTFClassifier(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/defences/test_adversarial_trainer.py
+++ b/tests/defences/test_adversarial_trainer.py
@@ -129,6 +129,7 @@ class TestAdversarialTrainer(TestBase):
     """
     Test cases for the AdversarialTrainer class.
     """
+
     def test_classifier_match(self):
         attack = FastGradientMethod(self.classifier_k)
         adv_trainer = AdversarialTrainer(self.classifier_k, attack)
@@ -206,6 +207,7 @@ class TestAdversarialTrainer(TestBase):
             def get_batch(self):
                 ids = np.random.choice(self.size, size=min(self.size, self.batch_size), replace=False)
                 return self.x[ids], self.y[ids]
+
         generator = MyDataGenerator(x_train, y_train, x_train.shape[0], 128)
 
         attack1 = FastGradientMethod(self.classifier_k)

--- a/tests/defences/test_feature_squeezing.py
+++ b/tests/defences/test_feature_squeezing.py
@@ -38,9 +38,9 @@ class TestFeatureSqueezing(unittest.TestCase):
         x = np.ones((m, n))
 
         for depth in range(1, 50):
-            preproc = FeatureSqueezing(bit_depth=depth)
-            squeezed_x, _ = preproc(x)
-            self.assertTrue((squeezed_x == 1).all())
+            preproc = FeatureSqueezing(clip_values=(0, 1), bit_depth=depth)
+            x_squeezed, _ = preproc(x)
+            self.assertTrue((x_squeezed == 1).all())
 
     def test_random(self):
         m, n = 1000, 20
@@ -48,23 +48,23 @@ class TestFeatureSqueezing(unittest.TestCase):
         x_zero = np.where(x < 0.5)
         x_one = np.where(x >= 0.5)
 
-        preproc = FeatureSqueezing(bit_depth=1)
-        squeezed_x, _ = preproc(x)
-        self.assertTrue((squeezed_x[x_zero] == 0.).all())
-        self.assertTrue((squeezed_x[x_one] == 1.).all())
+        preproc = FeatureSqueezing(clip_values=(0, 1), bit_depth=1)
+        x_squeezed, _ = preproc(x)
+        self.assertTrue((x_squeezed[x_zero] == 0.).all())
+        self.assertTrue((x_squeezed[x_one] == 1.).all())
 
-        preproc = FeatureSqueezing(bit_depth=2)
-        squeezed_x, _ = preproc(x)
-        self.assertFalse(np.logical_and(0. < squeezed_x, squeezed_x < 0.33).any())
-        self.assertFalse(np.logical_and(0.34 < squeezed_x, squeezed_x < 0.66).any())
-        self.assertFalse(np.logical_and(0.67 < squeezed_x, squeezed_x < 1.).any())
+        preproc = FeatureSqueezing(clip_values=(0, 1), bit_depth=2)
+        x_squeezed, _ = preproc(x)
+        self.assertFalse(np.logical_and(0. < x_squeezed, x_squeezed < 0.33).any())
+        self.assertFalse(np.logical_and(0.34 < x_squeezed, x_squeezed < 0.66).any())
+        self.assertFalse(np.logical_and(0.67 < x_squeezed, x_squeezed < 1.).any())
 
     def test_data_range(self):
         x = np.arange(5)
-        preproc = FeatureSqueezing(bit_depth=2, clip_values=(0, 4))
-        squeezed_x, _ = preproc(x)
+        preproc = FeatureSqueezing(clip_values=(0, 4), bit_depth=2)
+        x_squeezed, _ = preproc(x)
         self.assertTrue(np.array_equal(x, np.arange(5)))
-        self.assertTrue(np.allclose(squeezed_x, [0, 1.33, 2.67, 2.67, 4], atol=1e-1))
+        self.assertTrue(np.allclose(x_squeezed, [0, 1.33, 2.67, 2.67, 4], atol=1e-1))
 
 
 if __name__ == '__main__':

--- a/tests/defences/test_gaussian_augmentation.py
+++ b/tests/defences/test_gaussian_augmentation.py
@@ -68,6 +68,15 @@ class TestGaussianAugmentation(unittest.TestCase):
         self.assertTrue(x.shape == new_x.shape)
         self.assertFalse((x == new_x).all())
 
+    def test_failure_augmentation_fit_predict(self):
+        x = np.random.rand(10, 3)
 
-if __name__ == '__main__':
-    unittest.main()
+        # Assert that value error is raised
+        with self.assertRaises(ValueError) as context:
+            ga = GaussianAugmentation(augmentation=True, apply_fit=True, apply_predict=True)
+
+        self.assertTrue('If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`'
+                        ' must be `False`.' in str(context.exception))
+
+        if __name__ == '__main__':
+            unittest.main()

--- a/tests/defences/test_gaussian_augmentation.py
+++ b/tests/defences/test_gaussian_augmentation.py
@@ -69,11 +69,9 @@ class TestGaussianAugmentation(unittest.TestCase):
         self.assertFalse((x == new_x).all())
 
     def test_failure_augmentation_fit_predict(self):
-        x = np.random.rand(10, 3)
-
         # Assert that value error is raised
         with self.assertRaises(ValueError) as context:
-            ga = GaussianAugmentation(augmentation=True, apply_fit=True, apply_predict=True)
+            _ = GaussianAugmentation(augmentation=True, apply_fit=True, apply_predict=True)
 
         self.assertTrue('If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`'
                         ' must be `False`.' in str(context.exception))

--- a/tests/defences/test_gaussian_augmentation.py
+++ b/tests/defences/test_gaussian_augmentation.py
@@ -36,37 +36,37 @@ class TestGaussianAugmentation(unittest.TestCase):
     def test_small_size(self):
         x = np.arange(15).reshape((5, 3))
         ga = GaussianAugmentation(ratio=0.4)
-        new_x, _ = ga(x)
-        self.assertTrue(new_x.shape == (7, 3))
+        x_new, _ = ga(x)
+        self.assertTrue(x_new.shape == (7, 3))
 
     def test_double_size(self):
         x = np.arange(12).reshape((4, 3))
         ga = GaussianAugmentation()
-        new_x, _ = ga(x)
-        self.assertTrue(new_x.shape[0] == 2 * x.shape[0])
+        x_new, _ = ga(x)
+        self.assertTrue(x_new.shape[0] == 2 * x.shape[0])
 
     def test_multiple_size(self):
         x = np.arange(12).reshape((4, 3))
         ga = GaussianAugmentation(ratio=3.5)
-        new_x, _ = ga(x)
-        self.assertTrue(int(4.5 * x.shape[0]) == new_x.shape[0])
+        x_new, _ = ga(x)
+        self.assertTrue(int(4.5 * x.shape[0]) == x_new.shape[0])
 
     def test_labels(self):
         x = np.arange(12).reshape((4, 3))
         y = np.arange(8).reshape((4, 2))
 
         ga = GaussianAugmentation()
-        new_x, new_y = ga(x, y)
-        self.assertTrue(new_x.shape[0] == new_y.shape[0] == 8)
-        self.assertTrue(new_x.shape[1:] == x.shape[1:])
+        x_new, new_y = ga(x, y)
+        self.assertTrue(x_new.shape[0] == new_y.shape[0] == 8)
+        self.assertTrue(x_new.shape[1:] == x.shape[1:])
         self.assertTrue(new_y.shape[1:] == y.shape[1:])
 
     def test_no_augmentation(self):
         x = np.arange(12).reshape((4, 3))
         ga = GaussianAugmentation(augmentation=False)
-        new_x, _ = ga(x)
-        self.assertTrue(x.shape == new_x.shape)
-        self.assertFalse((x == new_x).all())
+        x_new, _ = ga(x)
+        self.assertTrue(x.shape == x_new.shape)
+        self.assertFalse((x == x_new).all())
 
     def test_failure_augmentation_fit_predict(self):
         # Assert that value error is raised

--- a/tests/defences/test_jpeg_compression.py
+++ b/tests/defences/test_jpeg_compression.py
@@ -101,7 +101,7 @@ class TestJpegCompression(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
 
-        self.assertTrue('min value should be 0.' in str(context.exception))
+        self.assertTrue('min value must be 0.' in str(context.exception))
 
     def test_failure_clip_values_unexpected_maximum(self):
         clip_values = (0, 2)
@@ -111,7 +111,7 @@ class TestJpegCompression(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
 
-        self.assertTrue('max value should be either 1 or 255.' in str(context.exception))
+        self.assertTrue('max value must be either 1 or 255.' in str(context.exception))
 
 
 if __name__ == '__main__':

--- a/tests/defences/test_jpeg_compression.py
+++ b/tests/defences/test_jpeg_compression.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import unittest
 
-from tensorflow.examples.tutorials.mnist import input_data
 from keras.datasets import cifar10
 import numpy as np
 
@@ -95,21 +94,19 @@ class TestJpegCompression(unittest.TestCase):
 
     def test_failure_clip_values_negative(self):
         clip_values = (-1, 1)
-        x = np.random.rand(10, 3)
 
         # Assert that value error is raised
         with self.assertRaises(ValueError) as context:
-            preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
+            _ = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
 
         self.assertTrue('min value must be 0.' in str(context.exception))
 
     def test_failure_clip_values_unexpected_maximum(self):
         clip_values = (0, 2)
-        x = np.random.rand(10, 3)
 
         # Assert that value error is raised
         with self.assertRaises(ValueError) as context:
-            preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
+            _ = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
 
         self.assertTrue('max value must be either 1 or 255.' in str(context.exception))
 

--- a/tests/defences/test_jpeg_compression.py
+++ b/tests/defences/test_jpeg_compression.py
@@ -36,42 +36,82 @@ class TestJpegCompression(unittest.TestCase):
         master_seed(1234)
 
     def test_one_channel(self):
+        clip_values = (0, 1)
         (x_train, _), (_, _), _, _ = load_mnist()
         x_train = x_train[:2]
-        preprocess = JpegCompression(quality=70)
-        compressed_x, _ = preprocess(x_train)
-        self.assertTrue((compressed_x.shape == x_train.shape))
-        self.assertTrue((compressed_x <= 1.0).all())
-        self.assertTrue((compressed_x >= 0.0).all())
+        preprocess = JpegCompression(clip_values=clip_values, quality=70)
+        x_compressed, _ = preprocess(x_train)
+        self.assertTrue((x_compressed.shape == x_train.shape))
+        self.assertTrue((x_compressed >= clip_values[0]).all())
+        self.assertTrue((x_compressed <= clip_values[1]).all())
 
-    def test_three_channels(self):
+    def test_three_channels_0_1(self):
+        clip_values = (0, 1)
         (train_features, _), (_, _) = cifar10.load_data()
         x = train_features[:2] / 255.0
-        preprocess = JpegCompression(quality=80)
-        compressed_x, _ = preprocess(x)
-        self.assertTrue((compressed_x.shape == x.shape))
-        self.assertTrue((compressed_x <= 1.0).all())
-        self.assertTrue((compressed_x >= 0.0).all())
+        preprocess = JpegCompression(clip_values=clip_values, quality=80)
+        x_compressed, _ = preprocess(x)
+        self.assertTrue((x_compressed.shape == x.shape))
+        self.assertTrue((x_compressed >= clip_values[0]).all())
+        self.assertTrue((x_compressed <= clip_values[1]).all())
+        self.assertAlmostEqual(x_compressed[0, 14, 14, 0], 0.92941177)
+        self.assertAlmostEqual(x_compressed[0, 14, 14, 1], 0.8039216)
+        self.assertAlmostEqual(x_compressed[0, 14, 14, 2], 0.6117647)
+
+    def test_three_channels_0_255(self):
+        clip_values = (0, 255)
+        (train_features, _), (_, _) = cifar10.load_data()
+        x = train_features[:2]
+        preprocess = JpegCompression(clip_values=clip_values, quality=80)
+        x_compressed, _ = preprocess(x)
+        self.assertTrue((x_compressed.shape == x.shape))
+        self.assertTrue((x_compressed >= clip_values[0]).all())
+        self.assertTrue((x_compressed <= clip_values[1]).all())
+        self.assertAlmostEqual(x_compressed[0, 14, 14, 0], 0.92941177 * clip_values[1], places=4)
+        self.assertAlmostEqual(x_compressed[0, 14, 14, 1], 0.8039216 * clip_values[1], places=4)
+        self.assertAlmostEqual(x_compressed[0, 14, 14, 2], 0.6117647 * clip_values[1], places=4)
 
     def test_channel_index(self):
+        clip_values = (0, 255)
         (train_features, _), (_, _) = cifar10.load_data()
-        x = train_features[:2] / 255.0
+        x = train_features[:2]
         x = np.swapaxes(x, 1, 3)
-        preprocess = JpegCompression(channel_index=1, quality=80)
-        compressed_x, _ = preprocess(x)
-        self.assertTrue((compressed_x.shape == x.shape))
-        self.assertTrue((compressed_x <= 1.0).all())
-        self.assertTrue((compressed_x >= 0.0).all())
+        preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
+        x_compressed, _ = preprocess(x)
+        self.assertTrue((x_compressed.shape == x.shape))
+        self.assertTrue((x_compressed >= clip_values[0]).all())
+        self.assertTrue((x_compressed <= clip_values[1]).all())
 
     def test_failure_feature_vectors(self):
+        clip_values = (0, 1)
         x = np.random.rand(10, 3)
-        preprocess = JpegCompression(channel_index=1, quality=80)
+        preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
 
         # Assert that value error is raised for feature vectors
         with self.assertRaises(ValueError) as context:
             preprocess(x)
 
         self.assertTrue('Feature vectors detected.' in str(context.exception))
+
+    def test_failure_clip_values_negative(self):
+        clip_values = (-1, 1)
+        x = np.random.rand(10, 3)
+
+        # Assert that value error is raised
+        with self.assertRaises(ValueError) as context:
+            preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
+
+        self.assertTrue('min value should be 0.' in str(context.exception))
+
+    def test_failure_clip_values_unexpected_maximum(self):
+        clip_values = (0, 2)
+        x = np.random.rand(10, 3)
+
+        # Assert that value error is raised
+        with self.assertRaises(ValueError) as context:
+            preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
+
+        self.assertTrue('max value should be either 1 or 255.' in str(context.exception))
 
 
 if __name__ == '__main__':

--- a/tests/defences/test_label_smoothing.py
+++ b/tests/defences/test_label_smoothing.py
@@ -39,20 +39,20 @@ class TestLabelSmoothing(unittest.TestCase):
         y[(range(m), np.random.choice(range(n), m))] = 1.
 
         ls = LabelSmoothing()
-        _, smooth_y = ls(None, y)
-        self.assertTrue(np.isclose(np.sum(smooth_y, axis=1), np.ones(m)).all())
-        self.assertTrue((np.max(smooth_y, axis=1) == np.ones(m)*0.9).all())
+        _, y_smooth = ls(None, y)
+        self.assertTrue(np.isclose(np.sum(y_smooth, axis=1), np.ones(m)).all())
+        self.assertTrue((np.max(y_smooth, axis=1) == np.ones(m) * 0.9).all())
 
     def test_customizing(self):
         m, n = 1000, 20
         y = np.zeros((m, n))
         y[(range(m), np.random.choice(range(n), m))] = 1.
 
-        ls = LabelSmoothing(max_value=1.0/n)
-        _, smooth_y = ls(None, y)
-        self.assertTrue(np.isclose(np.sum(smooth_y, axis=1), np.ones(m)).all())
-        self.assertTrue((np.max(smooth_y, axis=1) == np.ones(m) / n).all())
-        self.assertTrue(np.isclose(smooth_y, np.ones((m, n)) / n).all())
+        ls = LabelSmoothing(max_value=1.0 / n)
+        _, y_smooth = ls(None, y)
+        self.assertTrue(np.isclose(np.sum(y_smooth, axis=1), np.ones(m)).all())
+        self.assertTrue((np.max(y_smooth, axis=1) == np.ones(m) / n).all())
+        self.assertTrue(np.isclose(y_smooth, np.ones((m, n)) / n).all())
 
 
 if __name__ == '__main__':

--- a/tests/defences/test_pixel_defend.py
+++ b/tests/defences/test_pixel_defend.py
@@ -98,4 +98,3 @@ class TestPixelDefend(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/defences/test_pixel_defend.py
+++ b/tests/defences/test_pixel_defend.py
@@ -73,11 +73,11 @@ class TestPixelDefend(unittest.TestCase):
         self.pixelcnn = PyTorchClassifier(model=model, loss=loss_fn, optimizer=optimizer, input_shape=(1, 28, 28),
                                           nb_classes=10, clip_values=(0, 1))
         preprocess = PixelDefend(eps=5, pixel_cnn=self.pixelcnn)
-        defended_x, _ = preprocess(x_train)
+        x_defended, _ = preprocess(x_train)
 
-        self.assertTrue((defended_x.shape == x_train.shape))
-        self.assertTrue((defended_x <= 1.0).all())
-        self.assertTrue((defended_x >= 0.0).all())
+        self.assertTrue((x_defended.shape == x_train.shape))
+        self.assertTrue((x_defended <= 1.0).all())
+        self.assertTrue((x_defended >= 0.0).all())
 
     def test_feature_vectors(self):
         # Define the network
@@ -89,11 +89,11 @@ class TestPixelDefend(unittest.TestCase):
 
         x = np.random.rand(5, 4)
         preprocess = PixelDefend(eps=5, pixel_cnn=pixel_cnn)
-        defended_x, _ = preprocess(x)
+        x_defended, _ = preprocess(x)
 
-        self.assertTrue((defended_x.shape == x.shape))
-        self.assertTrue((defended_x <= 1.0).all())
-        self.assertTrue((defended_x >= 0.0).all())
+        self.assertTrue((x_defended.shape == x.shape))
+        self.assertTrue((x_defended <= 1.0).all())
+        self.assertTrue((x_defended >= 0.0).all())
 
 
 if __name__ == '__main__':

--- a/tests/defences/test_spatial_smoothing.py
+++ b/tests/defences/test_spatial_smoothing.py
@@ -68,9 +68,9 @@ class TestLocalSpatialSmoothing(unittest.TestCase):
 
         x_new = np.arange(9).reshape(1, 3, 3, 1)
         preprocess = SpatialSmoothing()
-        new_smooth_x, _ = preprocess(x_new)
+        x_new_smooth, _ = preprocess(x_new)
 
-        self.assertTrue((x_smooth[0, 0] == new_smooth_x[0, :, :, 0]).all())
+        self.assertTrue((x_smooth[0, 0] == x_new_smooth[0, :, :, 0]).all())
 
     def test_failure(self):
         x = np.arange(10).reshape(5, 2)

--- a/tests/defences/test_spatial_smoothing.py
+++ b/tests/defences/test_spatial_smoothing.py
@@ -39,8 +39,8 @@ class TestLocalSpatialSmoothing(unittest.TestCase):
 
         # Start to test
         for window_size in range(1, 20):
-            preprocess = SpatialSmoothing()
-            smoothed_x, _ = preprocess(x, window_size)
+            preprocess = SpatialSmoothing(window_size=window_size)
+            smoothed_x, _ = preprocess(x)
             self.assertTrue((smoothed_x == 1).all())
 
     def test_fix(self):
@@ -48,29 +48,29 @@ class TestLocalSpatialSmoothing(unittest.TestCase):
 
         # Start to test
         preprocess = SpatialSmoothing(window_size=3)
-        smooth_x, _ = preprocess(x)
-        self.assertTrue((smooth_x == np.array(
+        x_smooth, _ = preprocess(x)
+        self.assertTrue((x_smooth == np.array(
             [[[[0.2], [0.3], [0.3]], [[0.4], [0.5], [0.6]], [[0.5], [0.6], [0.6]]]]).astype(np.float32)).all())
 
         preprocess = SpatialSmoothing(window_size=1)
-        smooth_x, _ = preprocess(x)
-        self.assertTrue((smooth_x == x).all())
+        x_smooth, _ = preprocess(x)
+        self.assertTrue((x_smooth == x).all())
 
         preprocess = SpatialSmoothing(window_size=2)
-        smooth_x, _ = preprocess(x)
-        self.assertTrue((smooth_x == np.array(
+        x_smooth, _ = preprocess(x)
+        self.assertTrue((x_smooth == np.array(
             [[[[0.1], [0.2], [0.3]], [[0.7], [0.7], [0.8]], [[0.7], [0.7], [0.8]]]]).astype(np.float32)).all())
 
     def test_channels(self):
         x = np.arange(9).reshape(1, 1, 3, 3)
         preprocess = SpatialSmoothing(channel_index=1)
-        smooth_x, _ = preprocess(x)
+        x_smooth, _ = preprocess(x)
 
-        new_x = np.arange(9).reshape(1, 3, 3, 1)
+        x_new = np.arange(9).reshape(1, 3, 3, 1)
         preprocess = SpatialSmoothing()
-        new_smooth_x, _ = preprocess(new_x)
+        new_smooth_x, _ = preprocess(x_new)
 
-        self.assertTrue((smooth_x[0, 0] == new_smooth_x[0, :, :, 0]).all())
+        self.assertTrue((x_smooth[0, 0] == new_smooth_x[0, :, :, 0]).all())
 
     def test_failure(self):
         x = np.arange(10).reshape(5, 2)

--- a/tests/defences/test_thermometer_encoding.py
+++ b/tests/defences/test_thermometer_encoding.py
@@ -41,7 +41,7 @@ class TestThermometerEncoding(unittest.TestCase):
                       [[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]]]])
 
         # Create an instance of ThermometerEncoding
-        th_encoder = ThermometerEncoding(num_space=4)
+        th_encoder = ThermometerEncoding(clip_values=(0, 1), num_space=4)
 
         # Preprocess
         x_preproc, _ = th_encoder(x)
@@ -61,14 +61,14 @@ class TestThermometerEncoding(unittest.TestCase):
         x = np.random.rand(5, 2, 28, 28)
         x_copy = x.copy()
         num_space = 5
-        encoder = ThermometerEncoding(num_space=num_space, channel_index=1)
+        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channel_index=1)
         encoded_x, _ = encoder(x)
         self.assertTrue((x == x_copy).all())
         self.assertTrue(encoded_x.shape == (5, 10, 28, 28))
 
     def test_estimate_gradient(self):
         num_space = 5
-        encoder = ThermometerEncoding(num_space=num_space)
+        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space)
         x = np.random.rand(5, 28, 28, 1)
         grad = np.ones((5, 28, 28, num_space))
         estimated_grads = encoder.estimate_gradient(grad=grad, x=x)
@@ -77,7 +77,7 @@ class TestThermometerEncoding(unittest.TestCase):
     def test_feature_vectors(self):
         x = np.random.rand(10, 4)
         num_space = 5
-        encoder = ThermometerEncoding(num_space=num_space, channel_index=1)
+        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channel_index=1)
         encoded_x, _ = encoder(x)
         self.assertTrue(encoded_x.shape == (10, 20))
 

--- a/tests/defences/test_thermometer_encoding.py
+++ b/tests/defences/test_thermometer_encoding.py
@@ -36,9 +36,9 @@ class TestThermometerEncoding(unittest.TestCase):
     def test_channel_last(self):
         # Test data
         x = np.array([[[[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]],
-                      [[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]]],
+                       [[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]]],
                       [[[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]],
-                      [[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]]]])
+                       [[0.2, 0.6, 0.8], [0.9, 0.4, 0.3], [0.2, 0.8, 0.5]]]])
 
         # Create an instance of ThermometerEncoding
         th_encoder = ThermometerEncoding(clip_values=(0, 1), num_space=4)
@@ -50,11 +50,13 @@ class TestThermometerEncoding(unittest.TestCase):
         self.assertTrue(x_preproc.shape == (2, 2, 3, 12))
 
         true_value = np.array([[[[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1], [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1],
-                                [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]], [[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1],
-                                [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1], [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]]],
-                                [[[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1], [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1],
-                                [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]], [[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1],
-                                [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1], [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]]]])
+                                 [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]], [[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1],
+                                                                         [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1],
+                                                                         [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]]],
+                               [[[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1], [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1],
+                                 [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]], [[1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1],
+                                                                         [0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1],
+                                                                         [1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1]]]])
         self.assertTrue((x_preproc == true_value).all())
 
     def test_channel_first(self):
@@ -62,9 +64,9 @@ class TestThermometerEncoding(unittest.TestCase):
         x_copy = x.copy()
         num_space = 5
         encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channel_index=1)
-        encoded_x, _ = encoder(x)
+        x_encoded, _ = encoder(x)
         self.assertTrue((x == x_copy).all())
-        self.assertTrue(encoded_x.shape == (5, 10, 28, 28))
+        self.assertTrue(x_encoded.shape == (5, 10, 28, 28))
 
     def test_estimate_gradient(self):
         num_space = 5
@@ -78,8 +80,9 @@ class TestThermometerEncoding(unittest.TestCase):
         x = np.random.rand(10, 4)
         num_space = 5
         encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channel_index=1)
-        encoded_x, _ = encoder(x)
-        self.assertTrue(encoded_x.shape == (10, 20))
+        x_encoded, _ = encoder(x)
+        self.assertTrue(x_encoded.shape == (10, 20))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/defences/test_variance_minimization.py
+++ b/tests/defences/test_variance_minimization.py
@@ -34,22 +34,24 @@ class TestTotalVarMin(unittest.TestCase):
         master_seed(1234)
 
     def test_one_channel(self):
+        clip_values = (0, 1)
         x = np.random.rand(2, 28, 28, 1)
-        preprocess = TotalVarMin()
-        preprocessed_x, _ = preprocess(x)
-        self.assertTrue((preprocessed_x.shape == x.shape))
-        self.assertTrue((preprocessed_x <= 1.0).all())
-        self.assertTrue((preprocessed_x >= 0.0).all())
-        self.assertFalse((preprocessed_x == x).all())
+        preprocess = TotalVarMin(clip_values = (0, 1))
+        x_preprocessed, _ = preprocess(x)
+        self.assertTrue((x_preprocessed.shape == x.shape))
+        self.assertTrue((x_preprocessed >= clip_values[0]).all())
+        self.assertTrue((x_preprocessed <= clip_values[1]).all())
+        self.assertFalse((x_preprocessed == x).all())
 
     def test_three_channels(self):
+        clip_values = (0, 1)
         x = np.random.rand(2, 32, 32, 3)
-        preprocess = TotalVarMin()
-        preprocessed_x, _ = preprocess(x)
-        self.assertTrue((preprocessed_x.shape == x.shape))
-        self.assertTrue((preprocessed_x <= 1.0).all())
-        self.assertTrue((preprocessed_x >= 0.0).all())
-        self.assertFalse((preprocessed_x == x).all())
+        preprocess = TotalVarMin(clip_values=clip_values)
+        x_preprocessed, _ = preprocess(x)
+        self.assertTrue((x_preprocessed.shape == x.shape))
+        self.assertTrue((x_preprocessed >= clip_values[0]).all())
+        self.assertTrue((x_preprocessed <= clip_values[1]).all())
+        self.assertFalse((x_preprocessed == x).all())
 
     def test_failure_feature_vectors(self):
         x = np.random.rand(10, 3)

--- a/tests/defences/test_variance_minimization.py
+++ b/tests/defences/test_variance_minimization.py
@@ -36,7 +36,7 @@ class TestTotalVarMin(unittest.TestCase):
     def test_one_channel(self):
         clip_values = (0, 1)
         x = np.random.rand(2, 28, 28, 1)
-        preprocess = TotalVarMin(clip_values = (0, 1))
+        preprocess = TotalVarMin(clip_values=(0, 1))
         x_preprocessed, _ = preprocess(x)
         self.assertTrue((x_preprocessed.shape == x.shape))
         self.assertTrue((x_preprocessed >= clip_values[0]).all())

--- a/tests/detection/test_detector.py
+++ b/tests/detection/test_detector.py
@@ -40,6 +40,7 @@ class TestBinaryInputDetector(unittest.TestCase):
     """
     A unittest class for testing the binary input detector.
     """
+
     def setUp(self):
         # Set master seed
         master_seed(1234)
@@ -101,6 +102,7 @@ class TestBinaryActivationDetector(unittest.TestCase):
     """
     A unittest class for testing the binary activation detector.
     """
+
     def setUp(self):
         # Set master seed
         master_seed(1234)

--- a/tests/poison_detection/test_activation_defence.py
+++ b/tests/poison_detection/test_activation_defence.py
@@ -227,10 +227,11 @@ class TestActivationDefence(unittest.TestCase):
 
         # Other method (since it's cross validation we can't assert to a concrete number).
         improvement, _ = ActivationDefence.relabel_poison_cross_validation(self.classifier, x_poison,
-                                                          y_fix, n_splits=2,
-                                                          tolerable_backdoor=0.01,
-                                                          max_epochs=5, batch_epochs=10)
+                                                                           y_fix, n_splits=2,
+                                                                           tolerable_backdoor=0.01,
+                                                                           max_epochs=5, batch_epochs=10)
         self.assertGreaterEqual(improvement, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -254,7 +254,7 @@ class TestTFDataGenerator(unittest.TestCase):
 
         def generator(batch_size=5):
             while True:
-                yield np.random.rand(batch_size, 5, 5, 1), np.random.randint(0, 10, size=10 * batch_size).\
+                yield np.random.rand(batch_size, 5, 5, 1), np.random.randint(0, 10, size=10 * batch_size). \
                     reshape(batch_size, -1)
 
         self.sess = tf.Session()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -72,7 +72,7 @@ class TestMetrics(unittest.TestCase):
         params = {"eps_step": 0.1,
                   "eps": 0.2}
         emp_robust = empirical_robustness(classifier, x_train, str('fgsm'), params)
-        self.assertLessEqual(emp_robust, 0.55)
+        self.assertLessEqual(emp_robust, 0.65)
 
     def test_loss_sensitivity(self):
         # Get MNIST

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -113,6 +113,7 @@ class TestMetrics(unittest.TestCase):
         classifier = KerasClassifier(model=model, clip_values=(0, 1), use_logits=False)
         return classifier
 
+
 #########################################
 # This part is the unit test for Clever.#
 #########################################
@@ -137,6 +138,7 @@ class TestClever(unittest.TestCase):
     """
     Unittest for Clever metrics.
     """
+
     def setUp(self):
         # Set master seed
         master_seed(42)
@@ -330,7 +332,7 @@ class TestClever(unittest.TestCase):
 
         scores = clever(krc, x_test[0], 5, 5, 3, 2, target=None, c_init=1, pool_factor=10)
         logger.info("Clever scores for n-1 classes: %s %s", str(scores), str(scores.shape))
-        self.assertTrue(scores.shape == (krc.nb_classes-1,))
+        self.assertTrue(scores.shape == (krc.nb_classes - 1,))
 
     def test_clever_l2_no_target_sorted(self):
         batch_size = 100
@@ -343,7 +345,7 @@ class TestClever(unittest.TestCase):
         scores = clever(krc, x_test[0], 5, 5, 3, 2, target=None, target_sort=True, c_init=1, pool_factor=10)
         logger.info("Clever scores for n-1 classes: %s %s", str(scores), str(scores.shape))
         # Should approx. be in decreasing value
-        self.assertTrue(scores.shape == (krc.nb_classes-1,))
+        self.assertTrue(scores.shape == (krc.nb_classes - 1,))
 
     def test_clever_l2_same_target(self):
         batch_size = 100

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -67,12 +67,12 @@ class TestMetrics(unittest.TestCase):
         params = {"eps_step": 1.,
                   "eps": 1.}
         emp_robust = empirical_robustness(classifier, x_train, str('fgsm'), params)
-        self.assertAlmostEqual(emp_robust, 1., 3)
+        self.assertAlmostEqual(emp_robust, 0.5006149157681419, 3)
 
         params = {"eps_step": 0.1,
                   "eps": 0.2}
         emp_robust = empirical_robustness(classifier, x_train, str('fgsm'), params)
-        self.assertLessEqual(emp_robust, 0.21)
+        self.assertLessEqual(emp_robust, 0.55)
 
     def test_loss_sensitivity(self):
         # Get MNIST

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,20 +111,20 @@ class TestUtils(unittest.TestCase):
         t = tuple(range(1, len(x.shape)))
         rand_sign = 1 - 2 * np.random.randint(0, 2, size=x.shape)
 
-        x_proj = projection(rand_sign*x, 3.14159, 1)
+        x_proj = projection(rand_sign * x, 3.14159, 1)
         self.assertEqual(x.shape, x_proj.shape)
         self.assertTrue(np.allclose(np.sum(np.abs(x_proj), axis=t), 3.14159, atol=10e-8))
 
-        x_proj = projection(rand_sign*x, 3.14159, 2)
+        x_proj = projection(rand_sign * x, 3.14159, 2)
         self.assertEqual(x.shape, x_proj.shape)
-        self.assertTrue(np.allclose(np.sqrt(np.sum(x_proj**2, axis=t)), 3.14159, atol=10e-8))
+        self.assertTrue(np.allclose(np.sqrt(np.sum(x_proj ** 2, axis=t)), 3.14159, atol=10e-8))
 
-        x_proj = projection(rand_sign*x, 0.314159, np.inf)
+        x_proj = projection(rand_sign * x, 0.314159, np.inf)
         self.assertEqual(x.shape, x_proj.shape)
         self.assertEqual(x_proj.min(), -0.314159)
         self.assertEqual(x_proj.max(), 0.314159)
 
-        x_proj = projection(rand_sign*x, 3.14159, np.inf)
+        x_proj = projection(rand_sign * x, 3.14159, np.inf)
         self.assertEqual(x.shape, x_proj.shape)
         self.assertEqual(x_proj.min(), -1.0)
         self.assertEqual(x_proj.max(), 1.0)
@@ -173,11 +173,11 @@ class TestUtils(unittest.TestCase):
         batch_size = 5
         x = np.random.rand(batch_size, 10, 10, 1)
         classifier = DummyClassifier()
-        preds = least_likely_class(x, classifier)
-        self.assertTrue(preds.shape == (batch_size, classifier.nb_classes))
+        predictions = least_likely_class(x, classifier)
+        self.assertTrue(predictions.shape == (batch_size, classifier.nb_classes))
 
-        expected_preds = np.array([[0, 0, 1, 0]] * batch_size)
-        self.assertTrue((preds == expected_preds).all())
+        expected_predictions = np.array([[0, 0, 1, 0]] * batch_size)
+        self.assertTrue((predictions == expected_predictions).all())
 
     def test_second_most_likely_class(self):
         class DummyClassifier:
@@ -186,17 +186,17 @@ class TestUtils(unittest.TestCase):
                 return 4
 
             def predict(self, x):
-                fake_preds = [0.1, 0.2, 0.05, 0.65]
-                return np.array([fake_preds] * x.shape[0])
+                fake_predictions = [0.1, 0.2, 0.05, 0.65]
+                return np.array([fake_predictions] * x.shape[0])
 
         batch_size = 5
         x = np.random.rand(batch_size, 10, 10, 1)
         classifier = DummyClassifier()
-        preds = second_most_likely_class(x, classifier)
-        self.assertTrue(preds.shape == (batch_size, classifier.nb_classes))
+        predictions = second_most_likely_class(x, classifier)
+        self.assertTrue(predictions.shape == (batch_size, classifier.nb_classes))
 
-        expected_preds = np.array([[0, 1, 0, 0]] * batch_size)
-        self.assertTrue((preds == expected_preds).all())
+        expected_predictions = np.array([[0, 1, 0, 0]] * batch_size)
+        self.assertTrue((predictions == expected_predictions).all())
 
     def test_get_label_conf(self):
         y = np.array([3, 1, 4, 1, 5, 9])

--- a/tests/wrappers/test_query_efficient_bb.py
+++ b/tests/wrappers/test_query_efficient_bb.py
@@ -28,7 +28,6 @@ from art.wrappers.query_efficient_bb import QueryEfficientBBGradientEstimation
 from art.classifiers import KerasClassifier
 from art.defences import FeatureSqueezing
 from art.utils import load_dataset, get_classifier_kr, get_iris_classifier_kr, get_labels_np_array, master_seed
-from art.utils import random_targets
 
 logger = logging.getLogger('testLogger')
 

--- a/tests/wrappers/test_query_efficient_bb.py
+++ b/tests/wrappers/test_query_efficient_bb.py
@@ -63,7 +63,7 @@ class TestWrappingClassifierAttack(unittest.TestCase):
         (x_train, y_train), (x_test, y_test) = self.mnist
 
         # Get the ready-trained Keras model and wrap it in query efficient gradient estimator wrapper
-        classifier = QueryEfficientBBGradientEstimation(self.classifier_k, 20, 1/64., round_samples=1/255.)
+        classifier = QueryEfficientBBGradientEstimation(self.classifier_k, 20, 1 / 64., round_samples=1 / 255.)
 
         attack = FastGradientMethod(classifier, eps=1)
         x_train_adv = attack.generate(x_train)
@@ -96,7 +96,7 @@ class TestWrappingClassifierAttack(unittest.TestCase):
         fs = FeatureSqueezing(bit_depth=1, clip_values=(0, 1))
         classifier = KerasClassifier(model=model, clip_values=(0, 1), defences=fs)
         # Wrap the classifier
-        classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1/64., round_samples=1/255.)
+        classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1 / 64., round_samples=1 / 255.)
 
         attack = FastGradientMethod(classifier, eps=1)
         x_train_adv = attack.generate(x_train)
@@ -137,7 +137,7 @@ class TestQueryEfficientVectors(unittest.TestCase):
         (_, _), (x_test, y_test) = self.iris
 
         classifier, _ = get_iris_classifier_kr()
-        classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1/64., round_samples=1 / 255.)
+        classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1 / 64., round_samples=1 / 255.)
 
         # Test untargeted attack
         attack = FastGradientMethod(classifier, eps=.1)
@@ -157,7 +157,7 @@ class TestQueryEfficientVectors(unittest.TestCase):
 
         # Recreate a classifier without clip values
         classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
-        classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1/64., round_samples=1 / 255.)
+        classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1 / 64., round_samples=1 / 255.)
         attack = FastGradientMethod(classifier, eps=1)
         x_test_adv = attack.generate(x_test)
         self.assertFalse((x_test == x_test_adv).all())


### PR DESCRIPTION
# Description

This PR changes the order of the preprocessing steps of applying defences and standardisation/normalisation. Up to now the classifiers first applied standardisation followed by defences. This can result in unexpected negative and/or unbounded input values for the defences. With this PR the defences will be applied first followed by standardisation, that way we can feed to unprocessed input image values to the classifier and use the same and comparable defence parameters across classifiers with different standardisation/normalisation parameters.

Fixes #84 

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
- OS
- Python version
- ART version or commit number
- TensorFlow / Keras / PyTorch / MXNet version

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
