### PR TITLE
Update Tensorflow and Python versions on Travis unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 language: python
 env:
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.12.0
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.0
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.12.3
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.1
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.14.0
 python:
   - "2.7"
@@ -10,7 +10,7 @@ python:
 matrix:
   include:
     - python: 3.5
-      env: KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.0
+      env: KERAS_BACKEND=tensorflow TENSORFLOW_V=1.14.0
       script:
         - (pycodestyle --max-line-length=120 art || exit 0) && (pylint -rn art || exit 0)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 dist: trusty
 language: python
 env:
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.5.0
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.7.0
-  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.10.0
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.12.0
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.0
+  - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.14.0
 python:
   - "2.7"
   - "3.5"
 matrix:
   include:
     - python: 3.5
-      env: KERAS_BACKEND=tensorflow TENSORFLOW_V=1.10.0
+      env: KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.0
       script:
         - (pycodestyle --max-line-length=120 art || exit 0) && (pylint -rn art || exit 0)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ env:
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.1
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.14.0
 python:
-  - "2.7"
-  - "3.5"
+   - "3.5"
 matrix:
   include:
     - python: 3.5
@@ -15,11 +14,7 @@ matrix:
         - (pycodestyle --max-line-length=120 art || exit 0) && (pylint -rn art || exit 0)
 
 before_install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - sed -i "s/tensorflow/tensorflow==${TENSORFLOW_V}/" test_requirements.txt
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ env:
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.13.1
   - KERAS_BACKEND=tensorflow TENSORFLOW_V=1.14.0
 python:
-   - "3.5"
+   - "3.6"
 matrix:
   include:
-    - python: 3.5
+    - python: 3.6
       env: KERAS_BACKEND=tensorflow TENSORFLOW_V=1.14.0
       script:
         - (pycodestyle --max-line-length=120 art || exit 0) && (pylint -rn art || exit 0)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The following **detector of poisoning attacks** is also supported:
 
 ### Installation with `pip`
 
-The toolbox is designed to run with Python 2 and 3.
+The toolbox is designed and tested to run with Python 3. 
 ART can be installed from the PyPi repository using `pip`:
 
 ```bash


### PR DESCRIPTION
# Description

This PR changes the Python and Tensorflow versions used on Travis CI for unit testing.

- drops testing with Python 2
- increases Python 3 version from 3.5 to 3.6
- increases Tensorflow versions from 1.5.0, 1.7.0, and 1.10.0 to 1.12.3, 1.13.1, and 1.14.0


Fixes #94 
Fixes #83

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
