### PR TITLE
Update test requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-keras
+keras==2.2.5
 h5py
 mxnet
 Pillow


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

Avoid testing with keras>=2.3.0 for now