### PR TITLE
Add check for incompatible numerical data type in standardisation

### DIFF
--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -203,6 +203,12 @@ class Classifier(ABC):
         :rtype: `np.ndarray`
         """
         if self.preprocessing is not None:
+            if x.dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
+                raise TypeError('This classifier is using `preprocessing` which can lead to negative values in the '
+                                'standardised input data `x`. The data type of input data `x` is {} which cannot '
+                                'represent negative values. Consider changing the data type of the input data `x` to '
+                                'e.g. np.float32.'.format(x.dtype))
+
             sub, div = self.preprocessing
             sub = np.asarray(sub, dtype=x.dtype)
             div = np.asarray(div, dtype=x.dtype)

--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -204,10 +204,9 @@ class Classifier(ABC):
         :raises: `TypeError`
         """
         if x.dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
-            raise TypeError('This classifier is using `preprocessing` which can lead to negative values in the '
-                            'standardised input data `x`. The data type of input data `x` is {} which cannot '
-                            'represent negative values. Consider changing the data type of the input data `x` to '
-                            'e.g. np.float32.'.format(x.dtype))
+            raise TypeError('The data type of input data `x` is {} and cannot represent negative values. Consider '
+                            'changing the data type of the input data `x` to a type that supports negative values e.g. '
+                            'np.float32.'.format(x.dtype))
 
         if self.preprocessing is not None:
             sub, div = self.preprocessing

--- a/art/classifiers/classifier.py
+++ b/art/classifiers/classifier.py
@@ -201,14 +201,15 @@ class Classifier(ABC):
         :type x: `np.ndarray`
         :return: Array for `x` with the standardized data.
         :rtype: `np.ndarray`
+        :raises: `TypeError`
         """
-        if self.preprocessing is not None:
-            if x.dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
-                raise TypeError('This classifier is using `preprocessing` which can lead to negative values in the '
-                                'standardised input data `x`. The data type of input data `x` is {} which cannot '
-                                'represent negative values. Consider changing the data type of the input data `x` to '
-                                'e.g. np.float32.'.format(x.dtype))
+        if x.dtype in [np.uint8, np.uint16, np.uint32, np.uint64]:
+            raise TypeError('This classifier is using `preprocessing` which can lead to negative values in the '
+                            'standardised input data `x`. The data type of input data `x` is {} which cannot '
+                            'represent negative values. Consider changing the data type of the input data `x` to '
+                            'e.g. np.float32.'.format(x.dtype))
 
+        if self.preprocessing is not None:
             sub, div = self.preprocessing
             sub = np.asarray(sub, dtype=x.dtype)
             div = np.asarray(div, dtype=x.dtype)


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

Add check for incompatible numerical data type in input standardisation of classifier

Fixes #224 

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
