### PR TITLE
Fix tests on branch master after reverting directly pushed commit

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,7 +8,7 @@ mxnet
 #torch>=1.2.0
 tensorflow
 scikit-learn==0.21.3
-xgboost
+xgboost==1.0.0
 lightgbm
 # Comment out because of compatibility issues with numpy versions
 # catboost

--- a/tests/classifiers/test_xgboost.py
+++ b/tests/classifiers/test_xgboost.py
@@ -102,7 +102,7 @@ class TestXGBoostClassifierPythonAPI(unittest.TestCase):
 
     def test_predict(self):
         y_predicted = self.classifier.predict(self.x_test[0:1])
-        y_expected = [0.02563512, 0.02925956, 0.94510525]
+        y_expected = [0.00280161, 0.00359648, 0.99360186]
         for i in range(3):
             self.assertAlmostEqual(y_predicted[0, i], y_expected[i], 4)
 

--- a/tests/metrics/test_verification_decision_trees.py
+++ b/tests/metrics/test_verification_decision_trees.py
@@ -110,7 +110,7 @@ class TestMetricsTrees(unittest.TestCase):
         average_bound, verified_error = rt.verify(x=self.x_test, y=self.y_test, eps_init=0.3,
                                                   nb_search_steps=10, max_clique=2, max_level=2)
 
-        self.assertEqual(average_bound, 0.009117187499999995)
+        self.assertEqual(average_bound, 0.009234374999999996)
         self.assertEqual(verified_error, 1.0)
 
     def test_RandomForest(self):

--- a/tests/metrics/test_verification_decision_trees.py
+++ b/tests/metrics/test_verification_decision_trees.py
@@ -66,8 +66,8 @@ class TestMetricsTrees(unittest.TestCase):
         average_bound, verified_error = rt.verify(x=self.x_test, y=self.y_test, eps_init=0.3,
                                                   nb_search_steps=10, max_clique=2, max_level=2)
 
-        self.assertEqual(average_bound, 0.035996093750000006)
-        self.assertEqual(verified_error, 0.96)
+        self.assertEqual(average_bound, 0.03186914062500001)
+        self.assertEqual(verified_error, 0.99)
 
     def test_LightGBM(self):
         train_data = lightgbm.Dataset(self.x_train, label=np.argmax(self.y_train, axis=1))
@@ -110,7 +110,7 @@ class TestMetricsTrees(unittest.TestCase):
         average_bound, verified_error = rt.verify(x=self.x_test, y=self.y_test, eps_init=0.3,
                                                   nb_search_steps=10, max_clique=2, max_level=2)
 
-        self.assertEqual(average_bound, 0.009234374999999996)
+        self.assertEqual(average_bound, 0.009117187499999995)
         self.assertEqual(verified_error, 1.0)
 
     def test_RandomForest(self):


### PR DESCRIPTION
# Description

This pull request updates the unittest for the recent release of XGBoost 1.0.0 to fix the failing tests on branch master after an unauthorised commit (fa3ede323b7ddce208e337b77f5c0180d141cb85) directly pushed to branch master.
