### PR TITLE
Fix label format processing in adversarial patch attack

### DIFF
--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -123,7 +123,7 @@ class AdversarialPatchNumpy(EvasionAttack):
         ) / 2.0 + self.classifier.clip_values[0]
         self.patch = np.ones(shape=self.classifier.input_shape).astype(np.float32) * mean_value
 
-        y_target = check_and_transform_label_format(labels=y)
+        y_target = check_and_transform_label_format(labels=y, nb_classes=self.classifier.nb_classes())
 
         for i_step in range(self.max_iter):
             if i_step == 0 or (i_step + 1) % 100 == 0:

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_numpy.py
@@ -97,7 +97,10 @@ class AdversarialPatchNumpy(EvasionAttack):
             "batch_size": batch_size,
         }
         self.set_params(**kwargs)
-        self.patch = None
+        mean_value = (
+            self.classifier.clip_values[1] - self.classifier.clip_values[0]
+        ) / 2.0 + self.classifier.clip_values[0]
+        self.patch = np.ones(shape=self.classifier.input_shape).astype(np.float32) * mean_value
 
     def generate(self, x, y=None, **kwargs):
         """
@@ -117,11 +120,6 @@ class AdversarialPatchNumpy(EvasionAttack):
                 "Feature vectors detected. The adversarial patch can only be applied to data with spatial "
                 "dimensions."
             )
-
-        mean_value = (
-            self.classifier.clip_values[1] - self.classifier.clip_values[0]
-        ) / 2.0 + self.classifier.clip_values[0]
-        self.patch = np.ones(shape=self.classifier.input_shape).astype(np.float32) * mean_value
 
         y_target = check_and_transform_label_format(labels=y, nb_classes=self.classifier.nb_classes())
 

--- a/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
+++ b/art/attacks/evasion/adversarial_patch/adversarial_patch_tensorflow.py
@@ -257,7 +257,7 @@ class AdversarialPatchTensorFlowV2(EvasionAttack):
 
         import tensorflow as tf
 
-        y = check_and_transform_label_format(labels=y)
+        y = check_and_transform_label_format(labels=y, nb_classes=self.classifier.nb_classes())
 
         shuffle = kwargs.get('shuffle', True)
 

--- a/tests/attacks/test_adversarial_patch.py
+++ b/tests/attacks/test_adversarial_patch.py
@@ -69,20 +69,20 @@ class TestAdversarialPatch(TestBase):
             scale_max=0.41,
             learning_rate=5.0,
             batch_size=10,
-            max_iter=500,
+            max_iter=5,
             patch_shape=(28, 28, 1),
         )
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(self.x_train_mnist, target, shuffle=False)
 
         if tf.__version__[0] == "2":
-            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.14372873, delta=0.05)
-            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.38899645, delta=0.05)
-            self.assertAlmostEqual(float(np.sum(patch_adv)), 417.5904846191406, delta=1.0)
+            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.55935985, delta=0.05)
+            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.5917497, delta=0.05)
+            self.assertAlmostEqual(float(np.sum(patch_adv)), 400.0701904296875, delta=1.0)
         else:
-            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.048357915, delta=0.05)
-            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.26751655, delta=0.05)
-            self.assertAlmostEqual(float(np.sum(patch_adv)), 458.03973388671875, delta=1.0)
+            self.assertAlmostEqual(patch_adv[8, 8, 0], 0.5332792, delta=0.05)
+            self.assertAlmostEqual(patch_adv[14, 14, 0], 0.54590017, delta=0.05)
+            self.assertAlmostEqual(float(np.sum(patch_adv)), 398.8515625, delta=1.0)
 
         if sess is not None:
             sess.close()
@@ -95,15 +95,15 @@ class TestAdversarialPatch(TestBase):
         krc = get_image_classifier_kr()
 
         attack_ap = AdversarialPatch(
-            krc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=500
+            krc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=5
         )
         master_seed(seed=1234)
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(self.x_train_mnist, target)
 
-        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.12921186, delta=0.05)
-        self.assertAlmostEqual(patch_adv[14, 14, 0], 0.030846387, delta=0.05)
-        self.assertAlmostEqual(float(np.sum(patch_adv)), 466.4248352050781, delta=1.0)
+        self.assertAlmostEqual(patch_adv[8, 8, 0], 0.7993435, delta=0.05)
+        self.assertAlmostEqual(patch_adv[14, 14, 0], 1.0, delta=0.05)
+        self.assertAlmostEqual(float(np.sum(patch_adv)), 392.3392333984375, delta=1.0)
 
     def test_pytorch(self):
         """
@@ -115,15 +115,15 @@ class TestAdversarialPatch(TestBase):
         x_train = np.reshape(self.x_train_mnist, (self.n_train, 1, 28, 28)).astype(np.float32)
 
         attack_ap = AdversarialPatch(
-            ptc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=500
+            ptc, rotation_max=0.5, scale_min=0.4, scale_max=0.41, learning_rate=5.0, batch_size=10, max_iter=5
         )
         master_seed(seed=1234)
         target = np.zeros(self.x_train_mnist.shape[0])
         patch_adv, _ = attack_ap.generate(x_train, target)
 
-        self.assertAlmostEqual(patch_adv[0, 8, 8], 0.18794201, delta=0.05)
+        self.assertAlmostEqual(patch_adv[0, 8, 8], 0.5002671, delta=0.05)
         self.assertAlmostEqual(patch_adv[0, 14, 14], 0.5109714, delta=0.05)
-        self.assertAlmostEqual(float(np.sum(patch_adv)), 365.93072509765625, delta=1.0)
+        self.assertAlmostEqual(float(np.sum(patch_adv)), 393.09832763671875, delta=1.0)
 
     def test_failure_feature_vectors(self):
         attack_params = {


### PR DESCRIPTION
# Description

The current development version of `AdversarialPatch` on `dev_1.3.0` does not transform index labels correctly. This pull request fixes this issue.

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
