### PR TITLE
Simple Gradient Check to identify bad gradients in classification models

### DIFF
--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -280,6 +280,28 @@ class LossGradientsMixin(ABC):
         :rtype: Format as expected by the `model`
         """
         raise NotImplementedError
+        
+    def gradient_check(self, x, y):
+        """
+        Compute the gradient of the loss function w.r.t. `x` and identify points where the gradient is zero, nan, or inf
+
+        :param x: Input with shape as expected by the classifier's model.
+        :type x: `np.ndarray`
+        :param y: Target values (class labels) one-hot-encoded of shape (nb_samples, nb_classes) or indices of shape
+                  (nb_samples,).
+        :type y: `np.ndarray`
+        :return: Array of booleans with the shape (len(x), 3). If true means the gradient of the loss w.r.t. the 
+                 particular `x` was bad (zero, nan, inf) 
+        :rtype: `np.ndarray, np.ndarray`
+        """
+        assert len(x) == len(y), "x and y must be the same length"
+
+        is_bad = []
+        for i in range(len(x)):
+            grad = self.loss_gradient([x[i]], [y[i]])
+            is_bad.append([(np.min(grad) == 0 and np.max(grad) == 0), np.any(np.isnan(grad)),  np.any(np.isinf(grad))])
+
+        return np.array(is_bad, dtype=bool)
 
     def _apply_preprocessing_gradient(self, x, gradients):
         """

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -280,28 +280,6 @@ class LossGradientsMixin(ABC):
         :rtype: Format as expected by the `model`
         """
         raise NotImplementedError
-        
-    def gradient_check(self, x, y):
-        """
-        Compute the gradient of the loss function w.r.t. `x` and identify points where the gradient is zero, nan, or inf
-
-        :param x: Input with shape as expected by the classifier's model.
-        :type x: `np.ndarray`
-        :param y: Target values (class labels) one-hot-encoded of shape (nb_samples, nb_classes) or indices of shape
-                  (nb_samples,).
-        :type y: `np.ndarray`
-        :return: Array of booleans with the shape (len(x), 3). If true means the gradient of the loss w.r.t. the 
-                 particular `x` was bad (zero, nan, inf) 
-        :rtype: `np.ndarray, np.ndarray`
-        """
-        assert len(x) == len(y), "x and y must be the same length"
-
-        is_bad = []
-        for i in range(len(x)):
-            grad = self.loss_gradient([x[i]], [y[i]])
-            is_bad.append([(np.min(grad) == 0 and np.max(grad) == 0), np.any(np.isnan(grad)),  np.any(np.isinf(grad))])
-
-        return np.array(is_bad, dtype=bool)
 
     def _apply_preprocessing_gradient(self, x, gradients):
         """

--- a/art/metrics/gradient_check.py
+++ b/art/metrics/gradient_check.py
@@ -1,0 +1,42 @@
+# MIT License
+#
+# Copyright (C) IBM Corporation 2018
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements gradient check functions for estimators
+"""
+
+def loss_gradient_check(classifier, x, y):
+        """
+        Compute the gradient of the loss function w.r.t. `x` and identify points where the gradient is zero, nan, or inf
+
+        :param x: Input with shape as expected by the classifier's model.
+        :type x: `np.ndarray`
+        :param y: Target values (class labels) one-hot-encoded of shape (nb_samples, nb_classes) or indices of shape
+                  (nb_samples,).
+        :type y: `np.ndarray`
+        :return: Array of booleans with the shape (len(x), 3). If true means the gradient of the loss w.r.t. the 
+                 particular `x` was bad (zero, nan, inf) 
+        :rtype: `np.ndarray, np.ndarray`
+        """
+        assert len(x) == len(y), "x and y must be the same length"
+
+        is_bad = []
+        for i in range(len(x)):
+            grad = classifier.loss_gradient([x[i]], [y[i]])
+            is_bad.append([(np.min(grad) == 0 and np.max(grad) == 0), np.any(np.isnan(grad)),  np.any(np.isinf(grad))])
+
+        return np.array(is_bad, dtype=bool)

--- a/tests/metrics/test_gradient_check.py
+++ b/tests/metrics/test_gradient_check.py
@@ -1,0 +1,95 @@
+# MIT License
+#
+# Copyright (C) IBM Corporation 2018
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import unittest
+
+import keras
+from keras.models import Sequential
+from keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
+import numpy as np
+import tensorflow as tf
+
+from art.estimators.classification.keras import KerasClassifier
+from art.metrics.gradient_check import loss_gradient_check
+from art.utils import load_mnist
+
+from tests.utils import master_seed
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 10
+NB_TRAIN = 100
+NB_TEST = 100
+
+
+class Test_Gradient_Check(unittest.TestCase):
+    def setUp(self):
+        master_seed(seed=42)
+
+    def test_loss_gradient_check(self):
+        (x_train, y_train), (x_test, y_test), _, _ = load_mnist()
+        x_train, y_train = x_train[:NB_TRAIN], y_train[:NB_TRAIN]
+        x_test, y_test = x_test[:NB_TEST], y_test[:NB_TEST]
+
+        # Get classifier and train like normal
+        classifier = _cnn_mnist([28, 28, 1])
+        classifier.fit(x_train, y_train, batch_size=BATCH_SIZE, nb_epochs=2)
+
+        # Check if the function works
+        is_bad = loss_gradient_check(classifier, x_test, y_test)
+
+        # Now check that the function detects bad gradients
+        # Set the weights of the convolution layer to zero
+        weights = classifier._model.layers[0].get_weights()
+        new_weights = [np.zeros(w.shape) for w in weights]
+        classifier._model.layers[0].set_weights(new_weights)
+        is_bad = loss_gradient_check(classifier, x_test, y_test)
+        
+        self.assertTrue(np.all(np.any(is_bad,1)))
+        
+        # Set the weights of the convolution layer to nan
+        weights = classifier._model.layers[0].get_weights()
+        new_weights = [np.empty(w.shape) for w in weights]
+        for i in range(len(new_weights)):
+            new_weights[i][:] = np.nan
+        classifier._model.layers[0].set_weights(new_weights)
+        is_bad = loss_gradient_check(classifier, x_test, y_test)
+
+        self.assertTrue(np.all(np.any(is_bad,1)))
+
+    @staticmethod
+    def _cnn_mnist(input_shape):
+        # Create simple CNN
+        model = Sequential()
+        model.add(Conv2D(4, kernel_size=(5, 5), activation="relu", input_shape=input_shape))
+        model.add(MaxPooling2D(pool_size=(2, 2)))
+        model.add(Flatten())
+        model.add(Dense(10, activation="softmax"))
+
+        model.compile(
+            loss=keras.losses.categorical_crossentropy, optimizer=keras.optimizers.Adam(lr=0.01), metrics=["accuracy"]
+        )
+
+        classifier = KerasClassifier(model=model, clip_values=(0, 1), use_logits=False)
+        return classifier
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request add the gradient_check() function to the abstract estimator class. Given a set of samples x and a set of labels y, the function will return a three boolean triple for each sample. Each value in the triple indicates if the loss gradient with respect to the sample is:

1. All zero
2. Contains NaN
3. Contains Inf

This change is intended to provide users easy access to check if the classifier has obfuscated gradients, which can break some whitebox attacks and result in users observing an artificially high adversarial robustness.

This function can also be used by the existing evasion attacks to check for bad gradients during the attack and issue a warning to the user rather than silently failing the attack and returning the original input sample. Doing so would require updating whitebox attack code during the generate call, which this pull request does not include.

Fixes #368

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Simple local tests where 2 models were trained using the TFClassifier and then the new function was called against each model. One model had a normal gradient and one model had an obfuscated gradient (zero gradient due to activation saturation).

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
