### PR TITLE
Define model as a property of all estimators

### DIFF
--- a/art/estimators/classification/GPy.py
+++ b/art/estimators/classification/GPy.py
@@ -73,7 +73,7 @@ class GPyGaussianProcessClassifier(ClassGradientsMixin, LossGradientsMixin, Clas
             preprocessing=preprocessing,
         )
         self._nb_classes = 2  # always binary
-        self.model = model
+        self._model = model
 
     # pylint: disable=W0221
     def class_gradient(self, x, label=None, eps=0.0001):

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -122,6 +122,10 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         else:
             self._reduce_labels = False
 
+    @property
+    def model(self):
+        return self._model._model
+
     def predict(self, x, batch_size=128, **kwargs):
         """
         Perform prediction for a batch of inputs.

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -134,6 +134,11 @@ class BaseEstimator(ABC):
 
     @property
     def model(self):
+        """
+        Return the model.
+
+        :return: The model.
+        """
         return self._model
 
     @property

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -133,6 +133,10 @@ class BaseEstimator(ABC):
         raise NotImplementedError
 
     @property
+    def model(self):
+        return self._model
+
+    @property
     def input_shape(self):
         """
         Return the shape of one input sample.

--- a/art/estimators/pytorch.py
+++ b/art/estimators/pytorch.py
@@ -29,3 +29,15 @@ class PyTorchEstimator(NeuralNetworkMixin, LossGradientsMixin, BaseEstimator):
     """
     Estimator class for PyTorch models.
     """
+
+    @property
+    def model(self):
+        """
+        Return the model.
+
+        :return: The model.
+        :rtype: `torch.nn.Module`
+        """
+        import torch
+        assert isinstance(self._model, torch.nn.Module)
+        return self._model

--- a/docs/modules/estimators.rst
+++ b/docs/modules/estimators.rst
@@ -3,8 +3,8 @@
 .. automodule:: art.estimators
 
 
-Base Class Estimators
----------------------
+Base Class Estimator
+--------------------
 .. autoclass:: BaseEstimator
    :members:
 
@@ -22,3 +22,45 @@ Mixin Base Class Decision Trees
 -------------------------------
 .. autoclass:: DecisionTreeMixin
    :members:
+
+Base Class KerasEstimator
+-------------------------
+.. autoclass:: KerasEstimator
+   :members:
+   :special-members: __init__
+   :inherited-members:
+
+Base Class MXEstimator
+----------------------
+.. autoclass:: MXEstimator
+   :members:
+   :special-members: __init__
+   :inherited-members:
+
+Base Class PyTorchEstimator
+---------------------------
+.. autoclass:: PyTorchEstimator
+   :members:
+   :special-members: __init__
+   :inherited-members:
+
+Base Class ScikitlearnEstimator
+-------------------------------
+.. autoclass:: ScikitlearnEstimator
+   :members:
+   :special-members: __init__
+   :inherited-members:
+
+Base Class TensorFlowEstimator
+------------------------------
+.. autoclass:: TensorFlowEstimator
+   :members:
+   :special-members: __init__
+   :inherited-members:
+
+Base Class TensorFlowV2Estimator
+--------------------------------
+.. autoclass:: TensorFlowV2Estimator
+   :members:
+   :special-members: __init__
+   :inherited-members:

--- a/docs/modules/estimators/classification.rst
+++ b/docs/modules/estimators/classification.rst
@@ -12,54 +12,62 @@ Mixin Base Class Class Gradients
 .. autoclass:: ClassGradientsMixin
    :members:
 
-BlackBox Wrapper
-----------------
+BlackBox Classifier
+-------------------
 .. autoclass:: BlackBoxClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Keras Wrapper
--------------
+Keras Classifier
+----------------
 .. autoclass:: KerasClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-MXNet Wrapper
--------------
+MXNet Classifier
+----------------
 .. autoclass:: MXClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-PyTorch Wrapper
----------------
+PyTorch Classifier
+------------------
 .. autoclass:: PyTorchClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-TensorFlow Wrapper
-------------------
+TensorFlow Classifier
+---------------------
 .. autoclass:: TensorFlowClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-TensorFlow v2 Wrapper
----------------------
+TensorFlow v2 Classifier
+------------------------
 .. autoclass:: TensorFlowV2Classifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Ensemble Wrapper
-----------------
+Ensemble Classifier
+-------------------
 .. autoclass:: EnsembleClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn Classifier Wrapper
--------------------------------
+Scikit-learn Classifier Classifier
+----------------------------------
 .. autofunction:: SklearnClassifier
 
-GPy Gaussian Process Wrapper
-----------------------------
+GPy Gaussian Process Classifier
+-------------------------------
 .. autoclass:: GPyGaussianProcessClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:

--- a/docs/modules/estimators/classification_scikitlearn.rst
+++ b/docs/modules/estimators/classification_scikitlearn.rst
@@ -7,56 +7,65 @@ Base Class Scikit-learn
 .. autoclass:: ScikitlearnClassifier
    :members:
 
-Scikit-learn DecisionTreeClassifier Wrapper
--------------------------------------------
+Scikit-learn DecisionTreeClassifier Classifier
+----------------------------------------------
 .. autoclass:: ScikitlearnDecisionTreeClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn ExtraTreeClassifier Wrapper
-----------------------------------------
+Scikit-learn ExtraTreeClassifier Classifier
+-------------------------------------------
 .. autoclass:: ScikitlearnExtraTreeClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn AdaBoostClassifier Wrapper
----------------------------------------
+Scikit-learn AdaBoostClassifier Classifier
+------------------------------------------
 .. autoclass:: ScikitlearnAdaBoostClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn BaggingClassifier Wrapper
---------------------------------------
+Scikit-learn BaggingClassifier Classifier
+-----------------------------------------
 .. autoclass:: ScikitlearnBaggingClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn ExtraTreesClassifier Wrapper
------------------------------------------
+Scikit-learn ExtraTreesClassifier Classifier
+--------------------------------------------
 .. autoclass:: ScikitlearnExtraTreesClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn GradientBoostingClassifier Wrapper
------------------------------------------------
+Scikit-learn GradientBoostingClassifier Classifier
+--------------------------------------------------
 .. autoclass:: ScikitlearnGradientBoostingClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn RandomForestClassifier Wrapper
--------------------------------------------
+Scikit-learn RandomForestClassifier Classifier
+----------------------------------------------
 .. autoclass:: ScikitlearnRandomForestClassifier
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn LogisticRegression Wrapper
----------------------------------------
+Scikit-learn LogisticRegression Classifier
+------------------------------------------
 .. autoclass:: ScikitlearnLogisticRegression
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
-Scikit-learn SVC Wrapper
-------------------------
+Scikit-learn SVC Classifier
+---------------------------
 .. autoclass:: ScikitlearnSVC
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:

--- a/docs/modules/estimators/object_detection.rst
+++ b/docs/modules/estimators/object_detection.rst
@@ -2,14 +2,16 @@
 ======================================
 .. automodule:: art.estimators.object_detection
 
-Mixin Base Class Object Detectors
----------------------------------
+Mixin Base Class Object Detector
+--------------------------------
 .. autoclass:: ObjectDetectorMixin
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:
 
 Object Detector PyTorch Faster-RCNN
 -----------------------------------
 .. autoclass:: PyTorchFasterRCNN
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:

--- a/docs/modules/estimators/regression.rst
+++ b/docs/modules/estimators/regression.rst
@@ -2,8 +2,9 @@
 ================================
 .. automodule:: art.estimators.regression
 
-Mixin Base Class Regressors
----------------------------
+Mixin Base Class Regressor
+--------------------------
 .. autoclass:: RegressorMixin
    :members:
-   :special-members:
+   :special-members: __init__
+   :inherited-members:


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request define model as a property of all estimators. This enables access to the model in a classifier.

Fixes #371 

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
