### PR TITLE
Fix bug in PixelAttack and ThresholdAttack

### DIFF
--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -164,6 +164,7 @@ class PixelThreshold(EvasionAttack):
                         self.min_th = threshold
                     if end < start:
                         if isinstance(image_result, list) and not image_result:
+                            success = False
                             image_result = image
                         break
             else:

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -163,6 +163,8 @@ class PixelThreshold(EvasionAttack):
                     if success:
                         self.min_th = threshold
                     if end < start:
+                        if isinstance(image_result, list) and not image_result:
+                            image_result = image
                         break
             else:
                 success, image_result = self._attack(image, target_class, self.th, maxiter)


### PR DESCRIPTION
# Description

This pull request fixes a small bug in PixelAttack and ThresholdAttack which occurs only if these attacks cannot find and adversarial example and return an empty list instead of the benign image instead.

Fixes #369 

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
