### PR TITLE
Add method get_params to BaseEstimator

### DIFF
--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -96,9 +96,37 @@ class BaseEstimator(ABC):
 
         if isinstance(self.preprocessing_defences, Preprocessor):
             self.preprocessing_defences = [self.preprocessing_defences]
+        elif isinstance(self.preprocessing_defences, list):
+            for defence in self.preprocessing_defences:
+                if not isinstance(defence, Preprocessor):
+                    raise ValueError(
+                        "All preprocessing defences have to be instance of "
+                        "art.defences.preprocessor.preprocessor.Preprocessor."
+                    )
+        elif self.preprocessing_defences is None:
+            pass
+        else:
+            raise ValueError(
+                "All preprocessing defences have to be instance of "
+                "art.defences.preprocessor.preprocessor.Preprocessor."
+            )
 
         if isinstance(self.postprocessing_defences, Postprocessor):
             self.postprocessing_defences = [self.postprocessing_defences]
+        elif isinstance(self.postprocessing_defences, list):
+            for defence in self.postprocessing_defences:
+                if not isinstance(defence, Postprocessor):
+                    raise ValueError(
+                        "All postprocessing defences have to be instance of "
+                        "art.defences.postprocessor.postprocessor.Postprocessor."
+                    )
+        elif self.postprocessing_defences is None:
+            pass
+        else:
+            raise ValueError(
+                "All postprocessing defences have to be instance of "
+                "art.defences.postprocessor.postprocessor.Postprocessor."
+            )
 
         if self.preprocessing is not None and len(self.preprocessing) != 2:
             raise ValueError(
@@ -107,9 +135,20 @@ class BaseEstimator(ABC):
 
         return self
 
+    def get_params(self):
+        """
+        Get all parameters and their values of this estimator.
+
+        :return: A dictionary of string parameter names to their value.
+        """
+        params = dict()
+        for key in self.estimator_params:
+            params[key] = getattr(self, key)
+        return params
+
     @abstractmethod
     def predict(self, x, **kwargs):  # lgtm [py/inheritance/incorrect-overridden-signature]
-        r"""
+        """
         Perform prediction of the estimator for input `x`.
 
         :param x: Samples.


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request adds the new method `get_params` to `BaseEstimator`. This method returns a dictionary of the instances parameters names to their values. This pull request also adds more detailed checks to `set_params`.

Fixes #374 

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
