### PR TITLE
Estimator - clip value dtype

### DIFF
--- a/art/estimators/classification/ensemble.py
+++ b/art/estimators/classification/ensemble.py
@@ -92,10 +92,10 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
             if not isinstance(classifier, NeuralNetworkMixin):
                 raise TypeError("Expected type `Classifier`, found %s instead." % type(classifier))
 
-            if np.array_equal(clip_values, classifier.clip_values):
+            if np.array_equal(self.clip_values, classifier.clip_values):
                 raise ValueError(
                     "Incompatible `clip_values` between classifiers in the ensemble. Found %s and %s."
-                    % (str(clip_values), str(classifier.clip_values))
+                    % (str(self.clip_values), str(classifier.clip_values))
                 )
 
             if classifier.nb_classes != classifiers[0].nb_classes:

--- a/art/estimators/classification/ensemble.py
+++ b/art/estimators/classification/ensemble.py
@@ -92,7 +92,7 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
             if not isinstance(classifier, NeuralNetworkMixin):
                 raise TypeError("Expected type `Classifier`, found %s instead." % type(classifier))
 
-            if clip_values != classifier.clip_values:
+            if np.array_equal(clip_values, classifier.clip_values):
                 raise ValueError(
                     "Incompatible `clip_values` between classifiers in the ensemble. Found %s and %s."
                     % (str(clip_values), str(classifier.clip_values))

--- a/art/estimators/classification/ensemble.py
+++ b/art/estimators/classification/ensemble.py
@@ -92,7 +92,7 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
             if not isinstance(classifier, NeuralNetworkMixin):
                 raise TypeError("Expected type `Classifier`, found %s instead." % type(classifier))
 
-            if np.array_equal(self.clip_values, classifier.clip_values):
+            if not np.array_equal(self.clip_values, classifier.clip_values):
                 raise ValueError(
                     "Incompatible `clip_values` between classifiers in the ensemble. Found %s and %s."
                     % (str(self.clip_values), str(classifier.clip_values))

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -94,11 +94,11 @@ class BaseEstimator(ABC):
                 )
             if np.array(self._clip_values[0] >= self._clip_values[1]).any():
                 raise ValueError("Invalid `clip_values`: min >= max.")
-
-        if isinstance(self._clip_values, np.ndarray):
-            self._clip_values = self._clip_values.astype(ART_NUMPY_DTYPE)
-        else:
-            self._clip_values = np.array(self._clip_values, dtype=ART_NUMPY_DTYPE)
+            
+            if isinstance(self._clip_values, np.ndarray):
+                self._clip_values = self._clip_values.astype(ART_NUMPY_DTYPE)
+            else:
+                self._clip_values = np.array(self._clip_values, dtype=ART_NUMPY_DTYPE)
             
         if isinstance(self.preprocessing_defences, Preprocessor):
             self.preprocessing_defences = [self.preprocessing_defences]
@@ -269,8 +269,11 @@ class BaseEstimator(ABC):
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        attributes = {(k[1:], v) if k[0] == "_" else (k, v) for (k, v) in self.__dict__.items()}
-        attributes = ["{}={}".format(k, v) for (k, v) in attributes]
+        attributes = {}
+        for k, v in self.__dict__.items():
+            k = k[1:] if k[0] == "_" else k
+            attributes[k] = v
+        attributes = ["{}={}".format(k, v) for k, v in attributes.items()]
         repr_string = class_name + "(" + ", ".join(attributes) + ")"
         return repr_string
 

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
+from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor.preprocessor import Preprocessor
 from art.defences.postprocessor.postprocessor import Postprocessor
 
@@ -94,6 +95,11 @@ class BaseEstimator(ABC):
             if np.array(self._clip_values[0] >= self._clip_values[1]).any():
                 raise ValueError("Invalid `clip_values`: min >= max.")
 
+        if isinstance(self._clip_values, np.ndarray):
+            self._clip_values = self._clip_values.astype(ART_NUMPY_DTYPE)
+        else:
+            self._clip_values = np.array(self._clip_values, dtype=ART_NUMPY_DTYPE)
+            
         if isinstance(self.preprocessing_defences, Preprocessor):
             self.preprocessing_defences = [self.preprocessing_defences]
 

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -506,9 +506,12 @@ class NeuralNetworkMixin(ABC):
 
     def __repr__(self):
         name = self.__class__.__name__
-
-        attributes = {(k[1:], v) if k[0] == "_" else (k, v) for (k, v) in self.__dict__.items()}
-        attrs = ["{}={}".format(k, v) for (k, v) in attributes]
+        
+        attributes = {}
+        for k, v in self.__dict__.items():
+            k = k[1:] if k[0] == "_" else k
+            attributes[k] = v
+        attrs = ["{}={}".format(k, v) for k, v in attributes.items()]
         repr_ = name + "(" + ", ".join(attrs) + ")"
 
         return repr_

--- a/tests/classifiersFrameworks/test_keras.py
+++ b/tests/classifiersFrameworks/test_keras.py
@@ -726,7 +726,7 @@ def test_repr(get_image_classifier_list):
         [
             "art.estimators.classification.keras.KerasClassifier",
             "use_logits=False, channel_index=3",
-            "clip_values=array([0.0, 1.0]), preprocessing_defences=None, " "postprocessing_defences=None, preprocessing=(0, 1)",
+            "clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, " "postprocessing_defences=None, preprocessing=(0, 1)",
             "input_layer=0, output_layer=0",
         ],
     )

--- a/tests/classifiersFrameworks/test_keras.py
+++ b/tests/classifiersFrameworks/test_keras.py
@@ -726,7 +726,7 @@ def test_repr(get_image_classifier_list):
         [
             "art.estimators.classification.keras.KerasClassifier",
             "use_logits=False, channel_index=3",
-            "clip_values=(0, 1), preprocessing_defences=None, " "postprocessing_defences=None, preprocessing=(0, 1)",
+            "clip_values=array([0.0, 1.0]), preprocessing_defences=None, " "postprocessing_defences=None, preprocessing=(0, 1)",
             "input_layer=0, output_layer=0",
         ],
     )

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -424,7 +424,7 @@ def test_repr(is_tf_version_2, get_image_classifier_list):
                 "input_shape=(28, 28, 1)",
                 "loss_object=<tensorflow.python.keras.losses." "SparseCategoricalCrossentropy",
                 "train_step=<function get_image_classifier_tf_v2." "<locals>.train_step",
-                "channel_index=3, clip_values=array([0.0, 1.0]), preprocessing_defences="
+                "channel_index=3, clip_values=array([0., 1.], dtype=float32), preprocessing_defences="
                 "None, postprocessing_defences=None, preprocessing=(0, 1))",
             ],
         )
@@ -443,7 +443,7 @@ def test_repr(is_tf_version_2, get_image_classifier_list):
                 "learning=None",
                 "sess=<tensorflow.python.client.session.Session object",
                 "TensorFlowClassifier",
-                "channel_index=3, clip_values=array([0.0, 1.0]), "
+                "channel_index=3, clip_values=array([0., 1.], dtype=float32), "
                 "preprocessing_defences=None, postprocessing_defences=None, "
                 "preprocessing=(0, 1))",
             ],

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -424,7 +424,7 @@ def test_repr(is_tf_version_2, get_image_classifier_list):
                 "input_shape=(28, 28, 1)",
                 "loss_object=<tensorflow.python.keras.losses." "SparseCategoricalCrossentropy",
                 "train_step=<function get_image_classifier_tf_v2." "<locals>.train_step",
-                "channel_index=3, clip_values=(0, 1), preprocessing_defences="
+                "channel_index=3, clip_values=array([0.0, 1.0]), preprocessing_defences="
                 "None, postprocessing_defences=None, preprocessing=(0, 1))",
             ],
         )
@@ -443,7 +443,7 @@ def test_repr(is_tf_version_2, get_image_classifier_list):
                 "learning=None",
                 "sess=<tensorflow.python.client.session.Session object",
                 "TensorFlowClassifier",
-                "channel_index=3, clip_values=(0, 1), "
+                "channel_index=3, clip_values=array([0.0, 1.0]), "
                 "preprocessing_defences=None, postprocessing_defences=None, "
                 "preprocessing=(0, 1))",
             ],

--- a/tests/estimators/classification/test_blackbox.py
+++ b/tests/estimators/classification/test_blackbox.py
@@ -88,7 +88,7 @@ class TestBlackBoxClassifier(TestBase):
         repr_ = repr(classifier)
 
         self.assertIn("BlackBoxClassifier", repr_)
-        self.assertIn("clip_values=array([  0., 255.], dtype=float32)", repr_)
+        self.assertIn("clip_values=[  0. 255.]", repr_)
         self.assertIn("defences=None", repr_)
         self.assertIn("preprocessing=(0, 1)", repr_)
 

--- a/tests/estimators/classification/test_blackbox.py
+++ b/tests/estimators/classification/test_blackbox.py
@@ -88,7 +88,7 @@ class TestBlackBoxClassifier(TestBase):
         repr_ = repr(classifier)
 
         self.assertIn("BlackBoxClassifier", repr_)
-        self.assertIn("clip_values=(0, 255)", repr_)
+        self.assertIn("clip_values=array([  0., 255.], dtype=float32)", repr_)
         self.assertIn("defences=None", repr_)
         self.assertIn("preprocessing=(0, 1)", repr_)
 

--- a/tests/estimators/classification/test_classifier.py
+++ b/tests/estimators/classification/test_classifier.py
@@ -131,7 +131,7 @@ class TestClassifierNeuralNetwork(TestBase):
         repr_ = repr(classifier)
         self.assertIn("ClassifierNeuralNetworkInstance", repr_)
         self.assertIn("channel_index=1", repr_)
-        self.assertIn("clip_values=(0, 1)", repr_)
+        self.assertIn("clip_values=[0. 1.]", repr_)
         self.assertIn("defences=None", repr_)
         self.assertIn("preprocessing=None", repr_)
 

--- a/tests/estimators/classification/test_ensemble.py
+++ b/tests/estimators/classification/test_ensemble.py
@@ -255,7 +255,7 @@ class TestEnsembleClassifier(TestBase):
         self.assertIn("art.estimators.classification.ensemble.EnsembleClassifier", repr_)
         self.assertIn("classifier_weights=array([0.5, 0.5])", repr_)
         self.assertIn(
-            "channel_index=3, clip_values=(0, 1), preprocessing_defences=None, "
+            "channel_index=3, clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, "
             "postprocessing_defences=None, preprocessing=(0, 1)",
             repr_,
         )

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -576,7 +576,7 @@ class TestKerasClassifierTensorFlow(TestBase):
         self.assertIn("art.estimators.classification.keras.KerasClassifier", repr_)
         self.assertIn("use_logits=False, channel_index=3", repr_)
         self.assertIn(
-            "clip_values=array([0., 1.], type=float32), preprocessing_defences=None, postprocessing_defences=None, " "preprocessing=(0, 1)",
+            "clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, postprocessing_defences=None, " "preprocessing=(0, 1)",
             repr_,
         )
         self.assertIn("input_layer=0, output_layer=0", repr_)

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -576,7 +576,7 @@ class TestKerasClassifierTensorFlow(TestBase):
         self.assertIn("art.estimators.classification.keras.KerasClassifier", repr_)
         self.assertIn("use_logits=False, channel_index=3", repr_)
         self.assertIn(
-            "clip_values=(0, 1), preprocessing_defences=None, postprocessing_defences=None, " "preprocessing=(0, 1)",
+            "clip_values=array([0., 1.], type=float32), preprocessing_defences=None, postprocessing_defences=None, " "preprocessing=(0, 1)",
             repr_,
         )
         self.assertIn("input_layer=0, output_layer=0", repr_)

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -561,7 +561,7 @@ class TestKerasClassifierTensorFlow(TestBase):
         with open(full_path, "rb") as load_file:
             loaded = pickle.load(load_file)
 
-        self.assertEqual(keras_model._clip_values, loaded._clip_values)
+        np.testing.assert_equal(keras_model._clip_values, loaded._clip_values)
         self.assertEqual(keras_model._channel_index, loaded._channel_index)
         self.assertEqual(keras_model._use_logits, loaded._use_logits)
         self.assertEqual(keras_model._input_layer, loaded._input_layer)

--- a/tests/estimators/classification/test_mxnet.py
+++ b/tests/estimators/classification/test_mxnet.py
@@ -208,7 +208,7 @@ class TestMXClassifier(TestBase):
         repr_ = repr(self.classifier)
         self.assertIn("art.estimators.classification.mxnet.MXClassifier", repr_)
         self.assertIn("input_shape=(1, 28, 28), nb_classes=10", repr_)
-        self.assertIn("channel_index=1, clip_values=(0, 1)", repr_)
+        self.assertIn("channel_index=1, clip_values=array([0., 1.], type=float32)", repr_)
         self.assertIn("defences=None, preprocessing=(0, 1)", repr_)
 
 

--- a/tests/estimators/classification/test_mxnet.py
+++ b/tests/estimators/classification/test_mxnet.py
@@ -208,7 +208,7 @@ class TestMXClassifier(TestBase):
         repr_ = repr(self.classifier)
         self.assertIn("art.estimators.classification.mxnet.MXClassifier", repr_)
         self.assertIn("input_shape=(1, 28, 28), nb_classes=10", repr_)
-        self.assertIn("channel_index=1, clip_values=array([0., 1.], type=float32)", repr_)
+        self.assertIn("channel_index=1, clip_values=array([0., 1.], dtype=float32)", repr_)
         self.assertIn("defences=None, preprocessing=(0, 1)", repr_)
 
 

--- a/tests/estimators/classification/test_pytorch.py
+++ b/tests/estimators/classification/test_pytorch.py
@@ -577,7 +577,7 @@ class TestPyTorchClassifier(TestBase):
         repr_ = repr(self.module_classifier)
         self.assertIn("art.estimators.classification.pytorch.PyTorchClassifier", repr_)
         self.assertIn("input_shape=(1, 28, 28), nb_classes=10, channel_index=1", repr_)
-        self.assertIn("clip_values=(0, 1)", repr_)
+        self.assertIn("clip_values=array([0., 1.], type=float32)", repr_)
         self.assertIn("defences=None, preprocessing=(0, 1)", repr_)
 
     def test_pickle(self):

--- a/tests/estimators/classification/test_pytorch.py
+++ b/tests/estimators/classification/test_pytorch.py
@@ -591,7 +591,7 @@ class TestPyTorchClassifier(TestBase):
         # Unpickle:
         with open(full_path, "rb") as f:
             loaded = pickle.load(f)
-            self.assertEqual(self.module_classifier._clip_values, loaded._clip_values)
+            np.testing.assert_equal(self.module_classifier._clip_values, loaded._clip_values)
             self.assertEqual(self.module_classifier._channel_index, loaded._channel_index)
             self.assertEqual(set(self.module_classifier.__dict__.keys()), set(loaded.__dict__.keys()))
 

--- a/tests/estimators/classification/test_pytorch.py
+++ b/tests/estimators/classification/test_pytorch.py
@@ -577,7 +577,7 @@ class TestPyTorchClassifier(TestBase):
         repr_ = repr(self.module_classifier)
         self.assertIn("art.estimators.classification.pytorch.PyTorchClassifier", repr_)
         self.assertIn("input_shape=(1, 28, 28), nb_classes=10, channel_index=1", repr_)
-        self.assertIn("clip_values=array([0., 1.], type=float32)", repr_)
+        self.assertIn("clip_values=array([0., 1.], dtype=float32)", repr_)
         self.assertIn("defences=None, preprocessing=(0, 1)", repr_)
 
     def test_pickle(self):

--- a/tests/poison_detection/test_activation_defence.py
+++ b/tests/poison_detection/test_activation_defence.py
@@ -26,7 +26,7 @@ from art.poison_detection import ActivationDefence
 from art.utils import load_mnist
 from art.visualization import convert_to_rgb
 
-from tests.utils import master_seed, TestBase
+from tests.utils import master_seed
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +198,7 @@ class TestActivationDefence(unittest.TestCase):
         ActivationDefence._pickle_classifier(self.classifier, filename)
         loaded = ActivationDefence._unpickle_classifier(filename)
 
-        self.assertEqual(self.classifier._clip_values.tolist(), loaded._clip_values.tolist())
+        np.testing.assert_equal(self.classifier._clip_values, loaded._clip_values)
         self.assertEqual(self.classifier._channel_index, loaded._channel_index)
         self.assertEqual(self.classifier._use_logits, loaded._use_logits)
         self.assertEqual(self.classifier._input_layer, loaded._input_layer)

--- a/tests/poison_detection/test_activation_defence.py
+++ b/tests/poison_detection/test_activation_defence.py
@@ -26,14 +26,14 @@ from art.poison_detection import ActivationDefence
 from art.utils import load_mnist
 from art.visualization import convert_to_rgb
 
-from tests.utils import master_seed
+from tests.utils import master_seed, TestBase
 
 logger = logging.getLogger(__name__)
 
 NB_TRAIN, NB_TEST, BATCH_SIZE = 300, 10, 128
 
 
-class TestActivationDefence(unittest.TestCase):
+class TestActivationDefence(TestBase):
     @classmethod
     def setUpClass(cls):
 

--- a/tests/poison_detection/test_activation_defence.py
+++ b/tests/poison_detection/test_activation_defence.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 NB_TRAIN, NB_TEST, BATCH_SIZE = 300, 10, 128
 
 
-class TestActivationDefence(TestBase):
+class TestActivationDefence(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
@@ -198,7 +198,7 @@ class TestActivationDefence(TestBase):
         ActivationDefence._pickle_classifier(self.classifier, filename)
         loaded = ActivationDefence._unpickle_classifier(filename)
 
-        self.assertEqual(self.classifier._clip_values, loaded._clip_values)
+        self.assertEqual(self.classifier._clip_values.tolist(), loaded._clip_values.tolist())
         self.assertEqual(self.classifier._channel_index, loaded._channel_index)
         self.assertEqual(self.classifier._use_logits, loaded._use_logits)
         self.assertEqual(self.classifier._input_layer, loaded._input_layer)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,11 +105,6 @@ class TestBase(unittest.TestCase):
         np.testing.assert_array_almost_equal(self._y_train_iris_original, self.y_train_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._x_test_iris_original, self.x_test_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._y_test_iris_original, self.y_test_iris, decimal=3)
-
-    def assertEqual(self, first, second, msg=None):
-        first = first.tolist() if isinstance(first, np.ndarray) else first
-        second = second.tolist() if isinstance(second, np.ndarray) else second
-        super(TestBase, self).assertEqual(first, second, msg)
         
 
 class ExpectedValue:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -106,6 +106,11 @@ class TestBase(unittest.TestCase):
         np.testing.assert_array_almost_equal(self._x_test_iris_original, self.x_test_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._y_test_iris_original, self.y_test_iris, decimal=3)
 
+    def assertEqual(self, first, second, msg=None):
+        first = first.tolist() if isinstance(first, np.ndarray) else first
+        second = second.tolist() if isinstance(second, np.ndarray) else second
+        super(TestBase, self).assertEqual(first, second, msg)
+        
 
 class ExpectedValue:
     def __init__(self, value, decimals):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,6 +105,11 @@ class TestBase(unittest.TestCase):
         np.testing.assert_array_almost_equal(self._y_train_iris_original, self.y_train_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._x_test_iris_original, self.x_test_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._y_test_iris_original, self.y_test_iris, decimal=3)
+
+    def assertEqual(self, first, second, msg=None):
+        first = first.tolist() if isinstance(first, np.ndarray) else first
+        second = second.tolist() if isinstance(second, np.ndarray) else second
+        super(TestBase, self).assertEqual(first, second, msg)
         
 
 class ExpectedValue:


### PR DESCRIPTION
Signed-off-by: Lin Li <linli.tree@outlook.com>

# Description

Fix the bug of unexpected dtype conversion caused by the clip_values in the class Estimator when setting random initialization for the FGM or PGD adversaries.

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Successfully perform PGD and FGM attack with the `num_random_init` variable greater than 0.

**Test Configuration**:
- Ubuntu 18.04
- Pythton 3.7.6
- ART dev1.3.0
- PyTorch 1.4.0

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
