### PR TITLE
Add support for video data to the JPEG compression defense

### DIFF
--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -26,8 +26,8 @@ This module implements the JPEG compression defence `JpegCompression`.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from io import BytesIO
 import logging
+from io import BytesIO
 
 import numpy as np
 
@@ -97,15 +97,12 @@ class JpegCompression(Preprocessor):
 
         if len(x.shape) == 2:
             raise ValueError(
-                "Feature vectors detected. JPEG compression can only be applied to data with spatial" "dimensions."
+                "Feature vectors detected. JPEG compression can only be applied to data with spatial dimensions."
             )
-
-        if self.channel_index >= len(x.shape):
-            raise ValueError("Channel index does not match input shape.")
 
         if np.min(x) < 0.0:
             raise ValueError(
-                "Negative values in input `x` detected. The JPEG compression defence requires unnormalized" "input."
+                "Negative values in input `x` detected. The JPEG compression defence requires unnormalized input."
             )
 
         # Swap channel index
@@ -130,6 +127,9 @@ class JpegCompression(Preprocessor):
             elif x_i.shape[-1] == 3:
                 x_i = Image.fromarray(x_i, mode="RGB")
             else:
+                import pdb
+
+                pdb.set_trace()
                 logger.log(level=40, msg="Currently only support `RGB` and `L` images.")
                 raise NotImplementedError("Currently only support `RGB` and `L` images.")
 
@@ -180,23 +180,23 @@ class JpegCompression(Preprocessor):
         super(JpegCompression, self).set_params(**kwargs)
 
         if not isinstance(self.quality, (int, np.int)) or self.quality <= 0 or self.quality > 100:
-            logger.error("Image quality must be a positive integer <= 100.")
             raise ValueError("Image quality must be a positive integer <= 100.")
 
-        if not isinstance(self.channel_index, (int, np.int)) or self.channel_index <= 0:
-            logger.error("Data channel must be a positive integer. The batch dimension is not a valid channel.")
-            raise ValueError("Data channel must be a positive integer. The batch dimension is not a valid channel.")
+        if not (isinstance(self.channel_index, (int, np.int)) and self.channel_index in [1, 3]):
+            raise ValueError(
+                "Data channel must be an integer equal to 1 or 2. The batch dimension is not a valid channel."
+            )
 
         if len(self.clip_values) != 2:
-            raise ValueError("`clip_values` should be a tuple of 2 floats or arrays containing the allowed data range.")
+            raise ValueError("'clip_values' should be a tuple of 2 floats or arrays containing the allowed data range.")
 
         if np.array(self.clip_values[0] >= self.clip_values[1]).any():
-            raise ValueError("Invalid `clip_values`: min >= max.")
+            raise ValueError("Invalid 'clip_values': min >= max.")
 
         if self.clip_values[0] != 0:
-            raise ValueError("`clip_values` min value must be 0.")
+            raise ValueError("'clip_values' min value must be 0.")
 
         if self.clip_values[1] != 1.0 and self.clip_values[1] != 255:
-            raise ValueError("`clip_values` max value must be either 1 or 255.")
+            raise ValueError("'clip_values' max value must be either 1 or 255.")
 
         return True

--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -117,6 +117,7 @@ class JpegCompression(Preprocessor):
         x_local = x_local.astype("uint8")
 
         # Convert to 'L' mode
+        # TODO: remove
         if x_local.shape[-1] == 1:
             x_local = np.reshape(x_local, x_local.shape[:-1])
 
@@ -127,9 +128,6 @@ class JpegCompression(Preprocessor):
             elif x_i.shape[-1] == 3:
                 x_i = Image.fromarray(x_i, mode="RGB")
             else:
-                import pdb
-
-                pdb.set_trace()
                 logger.log(level=40, msg="Currently only support `RGB` and `L` images.")
                 raise NotImplementedError("Currently only support `RGB` and `L` images.")
 
@@ -138,9 +136,11 @@ class JpegCompression(Preprocessor):
             x_i = Image.open(out)
             x_i = np.array(x_i)
             x_local[i] = x_i
+            # TODO replace with out.close()
             del out
 
         # Expand dim if black/white images
+        # TODO remove
         if len(x_local.shape) < 4:
             x_local = np.expand_dims(x_local, 3)
 
@@ -182,9 +182,9 @@ class JpegCompression(Preprocessor):
         if not isinstance(self.quality, (int, np.int)) or self.quality <= 0 or self.quality > 100:
             raise ValueError("Image quality must be a positive integer <= 100.")
 
-        if not (isinstance(self.channel_index, (int, np.int)) and self.channel_index in [1, 3]):
+        if not (isinstance(self.channel_index, (int, np.int)) and self.channel_index in [1, 3, 4]):
             raise ValueError(
-                "Data channel must be an integer equal to 1 or 2. The batch dimension is not a valid channel."
+                "Data channel must be an integer equal to 1, 3 or 4. The batch dimension is not a valid channel."
             )
 
         if len(self.clip_values) != 2:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -67,7 +67,6 @@ declare -a defences=("tests/defences/test_adversarial_trainer.py" \
                      "tests/defences/test_gaussian_augmentation.py" \
                      "tests/defences/test_gaussian_noise.py" \
                      "tests/defences/test_high_confidence.py" \
-                     "tests/defences/test_jpeg_compression.py" \
                      "tests/defences/test_label_smoothing.py" \
                      "tests/defences/test_pixel_defend.py" \
                      "tests/defences/test_reverse_sigmoid.py" \

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -45,7 +45,7 @@ class DataGenerator:
         self.image_data = image_data
 
     def get_data(self):
-        temporal_index = () if self.image_data else (3,)
+        temporal_index = () if self.image_data else (2,)
         if self.channels_first:
             data_shape = (self.batch_size,) + self.channels + temporal_index + (8, 12)
         else:
@@ -65,7 +65,7 @@ def image_batch(request, channels_first):
     return test_input, test_output
 
 
-@pytest.fixture(params=[1, 4], ids=["grayscale", "RGB"])
+@pytest.fixture(params=[1, 3], ids=["grayscale", "RGB"])
 def video_batch(request, channels_first):
     """
     Video fixtures of shape NFHWC and NCFHW.
@@ -95,7 +95,6 @@ class TestJpegCompression:
         assert_array_equal(jpeg_compression(test_input)[0], test_output)
 
     @pytest.mark.parametrize("channels_first", [True, False])
-    @pytest.mark.xfail(raises=NotImplementedError)
     def test_jpeg_compression_video_data(self, video_batch, channels_first):
         channel_index = 1 if channels_first else 4
         test_input, test_output = video_batch

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -18,18 +18,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import unittest
 
 import numpy as np
 import pytest
-from keras.datasets import cifar10
 from numpy.testing import assert_array_equal
-from tests.utils import master_seed
 
 # import art
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor import JpegCompression
-from art.utils import load_mnist
 
 logger = logging.getLogger(__name__)
 
@@ -138,89 +134,5 @@ class TestJpegCompression:
             JpegCompression(clip_values=(0, 2), channel_index=1)
 
 
-class TestJpegCompressionLegacy(unittest.TestCase):
-    def setUp(self):
-        master_seed(seed=1234)
-
-    def test_one_channel(self):
-        clip_values = (0, 1)
-        (x_train, _), (_, _), _, _ = load_mnist()
-        x_train = x_train[:2]
-        preprocess = JpegCompression(clip_values=clip_values, quality=70)
-        x_compressed, _ = preprocess(x_train)
-        self.assertEqual(x_compressed.shape, x_train.shape)
-        self.assertTrue((x_compressed >= clip_values[0]).all())
-        self.assertTrue((x_compressed <= clip_values[1]).all())
-
-    def test_three_channels_0_1(self):
-        clip_values = (0, 1)
-        (train_features, _), (_, _) = cifar10.load_data()
-        x = train_features[:2] / 255.0
-        x_original = x.copy()
-        preprocess = JpegCompression(clip_values=clip_values, quality=80)
-        x_compressed, _ = preprocess(x)
-        self.assertEqual(x_compressed.shape, x.shape)
-        self.assertTrue((x_compressed >= clip_values[0]).all())
-        self.assertTrue((x_compressed <= clip_values[1]).all())
-        self.assertAlmostEqual(x_compressed[0, 14, 14, 0], 0.92941177)
-        self.assertAlmostEqual(x_compressed[0, 14, 14, 1], 0.8039216)
-        self.assertAlmostEqual(x_compressed[0, 14, 14, 2], 0.6117647)
-        # Check that x has not been modified by attack and classifier
-        self.assertAlmostEqual(float(np.max(np.abs(x_original - x))), 0.0, delta=0.00001)
-
-    def test_three_channels_0_255(self):
-        clip_values = (0, 255)
-        (train_features, _), (_, _) = cifar10.load_data()
-        x = train_features[:2]
-        preprocess = JpegCompression(clip_values=clip_values, quality=80)
-        x_compressed, _ = preprocess(x)
-        self.assertEqual(x_compressed.shape, x.shape)
-        self.assertTrue((x_compressed >= clip_values[0]).all())
-        self.assertTrue((x_compressed <= clip_values[1]).all())
-        self.assertAlmostEqual(x_compressed[0, 14, 14, 0], 0.92941177 * clip_values[1], places=4)
-        self.assertAlmostEqual(x_compressed[0, 14, 14, 1], 0.8039216 * clip_values[1], places=4)
-        self.assertAlmostEqual(x_compressed[0, 14, 14, 2], 0.6117647 * clip_values[1], places=4)
-
-    def test_channel_index(self):
-        clip_values = (0, 255)
-        (train_features, _), (_, _) = cifar10.load_data()
-        x = train_features[:2]
-        x = np.swapaxes(x, 1, 3)
-        preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
-        x_compressed, _ = preprocess(x)
-        self.assertTrue((x_compressed.shape == x.shape))
-        self.assertTrue((x_compressed >= clip_values[0]).all())
-        self.assertTrue((x_compressed <= clip_values[1]).all())
-
-    def test_failure_feature_vectors(self):
-        clip_values = (0, 1)
-        x = np.random.rand(10, 3)
-        preprocess = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
-
-        # Assert that value error is raised for feature vectors
-        with self.assertRaises(ValueError) as context:
-            preprocess(x)
-
-        self.assertTrue("Feature vectors detected." in str(context.exception))
-
-    def test_failure_clip_values_negative(self):
-        clip_values = (-1, 1)
-
-        # Assert that value error is raised
-        with self.assertRaises(ValueError) as context:
-            _ = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
-
-        self.assertTrue("min value must be 0." in str(context.exception))
-
-    def test_failure_clip_values_unexpected_maximum(self):
-        clip_values = (0, 2)
-
-        # Assert that value error is raised
-        with self.assertRaises(ValueError) as context:
-            _ = JpegCompression(clip_values=clip_values, channel_index=1, quality=80)
-
-        self.assertIn("max value must be either 1 or 255.", str(context.exception))
-
-
-# if __name__ == "__main__":
-#    unittest.main()
+if __name__ == "__main__":
+    pytest.cmdline.main("-q -s {} --mlFramework=tensorflow --durations=0".format(__file__).split(" "))

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -26,6 +26,7 @@ from keras.datasets import cifar10
 from numpy.testing import assert_array_equal
 from tests.utils import master_seed
 
+# import art
 from art.config import ART_NUMPY_DTYPE
 from art.defences.preprocessor import JpegCompression
 from art.utils import load_mnist
@@ -101,6 +102,17 @@ class TestJpegCompression:
         jpeg_compression = JpegCompression(clip_values=(0, 255), channel_index=channel_index)
 
         assert_array_equal(jpeg_compression(test_input)[0], test_output)
+
+    @pytest.mark.parametrize("channels_first", [False])
+    def test_jpeg_compress(self, image_batch, channels_first):
+        test_input, test_output = image_batch
+        jpeg_compression = JpegCompression(clip_values=(0, 255))
+
+        image_mode = "RGB" if test_input.shape[-1] == 3 else "L"
+        test_single_input = np.squeeze(test_input[0]).astype(np.uint8)
+        test_single_output = np.squeeze(test_output[0]).astype(np.uint8)
+
+        assert_array_equal(jpeg_compression._compress(test_single_input, image_mode), test_single_output)
 
     def test_channel_index_error(self):
         exc_msg = "Data channel must be an integer equal to 1, 3 or 4. The batch dimension is not a valid channel."


### PR DESCRIPTION
# Description

Add possibility to use the JPEG compression preprocessor with video data. 

Additional changes:

* Fix a minor bug in the previous implementation where input of shape `NCHW` was transposed to `NWHC`.
* Reduce running time of tests from 1.05s to 0.05s.

Related to #408

## Type of change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)

# Testing

Several tests were provided to handle the video data case. Furthermore, the current tests have been moved to the `pytest` framework.

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
