### PR TITLE
Add deprecation utilities

### DIFF
--- a/art/utils.py
+++ b/art/utils.py
@@ -20,13 +20,59 @@ Module providing convenience functions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import logging
 import math
+import os
+import warnings
+from functools import wraps
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------------------------------------- DEPRECATION
+
+
+def deprecated(end_version, *, reason="", replaced_by=""):
+    """
+    Deprecate a function or method and raise a `DeprecationWarning`.
+
+    The `@deprecated` decorator is used to deprecate functions and methods. Several cases are supported. For example
+    one can use it to depcreate a function that has become redundant or renaming a function. The following code examples
+    provide different use cases of how to use decorator.
+
+    .. code-block:: python
+
+    @deprecated("0.1.5", replaced_by="sum")
+    def simple_addition(a, b):
+        return a + b
+
+    :param end_version: Release version of removal.
+    :type end_version: `str`
+    :param reason: Additional deprecation reason.
+    :type reason: `str`
+    :param replaced_by: Function that replaces deprecated function.
+    :type replaced_by: `str`
+    """
+
+    def decorator(function):
+        reason_msg = "\n" + reason if reason else reason
+        replaced_msg = f" It will be replaced by '{replaced_by}'." if replaced_by else replaced_by
+        deprecated_msg = (
+            f"Function '{function.__name__}' is deprecated and will be removed in future release {end_version}."
+        )
+
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            warnings.simplefilter("always", category=DeprecationWarning)
+            warnings.warn(deprecated_msg + replaced_msg + reason_msg, category=DeprecationWarning, stacklevel=2)
+            warnings.simplefilter("default", category=DeprecationWarning)
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 # ----------------------------------------------------------------------------------------------------- MATH OPERATIONS
@@ -424,8 +470,8 @@ def load_cifar10(raw=False):
     for i in range(1, 6):
         fpath = os.path.join(path, "data_batch_" + str(i))
         data, labels = load_batch(fpath)
-        x_train[(i - 1) * 10000: i * 10000, :, :, :] = data
-        y_train[(i - 1) * 10000: i * 10000] = labels
+        x_train[(i - 1) * 10000 : i * 10000, :, :, :] = data
+        y_train[(i - 1) * 10000 : i * 10000] = labels
 
     fpath = os.path.join(path, "test_batch")
     x_test, y_test = load_batch(fpath)
@@ -557,15 +603,15 @@ def load_iris(raw=False, test_set=0.3):
 
     # Split training and test sets
     split_index = int((1 - test_set) * len(data) / 3)
-    x_train = np.vstack((data[:split_index], data[50: 50 + split_index], data[100: 100 + split_index]))
-    y_train = np.vstack((labels[:split_index], labels[50: 50 + split_index], labels[100: 100 + split_index]))
+    x_train = np.vstack((data[:split_index], data[50 : 50 + split_index], data[100 : 100 + split_index]))
+    y_train = np.vstack((labels[:split_index], labels[50 : 50 + split_index], labels[100 : 100 + split_index]))
 
     if split_index >= 49:
         x_test, y_test = None, None
     else:
 
-        x_test = np.vstack((data[split_index:50], data[50 + split_index: 100], data[100 + split_index:]))
-        y_test = np.vstack((labels[split_index:50], labels[50 + split_index: 100], labels[100 + split_index:]))
+        x_test = np.vstack((data[split_index:50], data[50 + split_index : 100], data[100 + split_index :]))
+        y_test = np.vstack((labels[split_index:50], labels[50 + split_index : 100], labels[100 + split_index :]))
         assert len(x_train) + len(x_test) == 150
 
         # Shuffle test set

--- a/art/utils.py
+++ b/art/utils.py
@@ -75,6 +75,50 @@ def deprecated(end_version, *, reason="", replaced_by=""):
     return decorator
 
 
+def deprecated_keyword_arg(identifier, end_version, *, reason="", replaced_by=""):
+    """
+    Deprecate a keyword argument and raise a `DeprecationWarning`.
+
+    The `@deprecated_keyword_arg` decorator is used to deprecate keyword arguments. Several cases are supported. For
+    example one can use it to depcreate the default value of a keyword or rename a keyword identifier. The following
+    code examples provide different use cases of how to use the decorator.
+
+    .. code-block:: python
+
+    @deprecated_keyword_arg("verbose", "1.1.0", replaced_by="verbose=False")
+    def simple_addition(a, b, verbose=True):
+        return a + b
+
+    :param identifier: Keyword identifier.
+    :type identifier: `str`
+    :param end_version: Release version of removal.
+    :type end_version: `str`
+    :param reason: Additional deprecation reason.
+    :type reason: `str`
+    :param replaced_by: Function that replaces deprecated function.
+    :type replaced_by: `str`
+    """
+
+    def decorator(function):
+        reason_msg = "\n" + reason if reason else reason
+        replaced_msg = f" It will be replaced by '{replaced_by}'." if replaced_by else replaced_by
+        deprecated_msg = (
+            f"Keyword argument '{identifier}' in '{function.__name__}' is deprecated and will be removed in"
+            f" future release {end_version}."
+        )
+
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            warnings.simplefilter("always", category=DeprecationWarning)
+            warnings.warn(deprecated_msg + replaced_msg + reason_msg, category=DeprecationWarning, stacklevel=2)
+            warnings.simplefilter("default", category=DeprecationWarning)
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 # ----------------------------------------------------------------------------------------------------- MATH OPERATIONS
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -12,6 +12,9 @@ if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed attacks/evation tests"; fi
 pytest -q tests/defences/preprocessor --mlFramework="tensorflow" --durations=0
 if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed defences/preprocessor tests"; fi
 
+pytest -q tests/utils --mlFramework="tensorflow" --durations=0
+if [[ $? -ne 0 ]]; then exit_code=1; echo "Failed utils tests"; fi
+
 #Only classifier tests need to be run for each frameworks
 mlFrameworkList=("tensorflow" "keras" "pytorch" "scikitlearn")
 for mlFramework in "${mlFrameworkList[@]}"; do

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,68 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import pytest
+
+from art.utils import deprecated
+
+logger = logging.getLogger(__name__)
+
+
+class TestDeprecated:
+    """
+    Test the deprecation decorator functions and methods.
+    """
+
+    def test_deprecated_simple(self):
+        @deprecated("1.3.0")
+        def simple_addition(a, b):
+            return a + b
+
+        with pytest.deprecated_call():
+            simple_addition(1, 2)
+
+    def test_deprecated_reason_keyword(self, recwarn):
+        @deprecated("1.3.0", reason="With some reason message.")
+        def simple_addition(a, b):
+            return a + b
+
+        warn_msg_expected = (
+            "Function 'simple_addition' is deprecated and will be removed in future release 1.3.0."
+            "\nWith some reason message."
+        )
+
+        simple_addition(1, 2)
+        warn_obj = recwarn.pop(DeprecationWarning)
+        assert str(warn_obj.message) == warn_msg_expected
+
+    def test_deprecated_replaced_by_keyword(self, recwarn):
+        @deprecated("1.3.0", replaced_by="sum")
+        def simple_addition(a, b):
+            return a + b
+
+        warn_msg_expected = (
+            "Function 'simple_addition' is deprecated and will be removed in future release 1.3.0."
+            " It will be replaced by 'sum'."
+        )
+
+        simple_addition(1, 2)
+        warn_obj = recwarn.pop(DeprecationWarning)
+        assert str(warn_obj.message) == warn_msg_expected

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -22,6 +22,7 @@ import logging
 import pytest
 
 from art.utils import deprecated
+from art.utils import deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +67,49 @@ class TestDeprecated:
         simple_addition(1, 2)
         warn_obj = recwarn.pop(DeprecationWarning)
         assert str(warn_obj.message) == warn_msg_expected
+
+
+class TestDeprecatedKeyword:
+    """
+    Test the deprecation decorator for keyword arguments.
+    """
+
+    def test_deprecated_simple(self):
+        @deprecated_keyword_arg("a", "1.3.0")
+        def simple_addition(a=1, b=1):
+            return a + b
+
+        with pytest.deprecated_call():
+            simple_addition()
+
+    def test_deprecated_reason_keyword(self, recwarn):
+        @deprecated_keyword_arg("a", "1.3.0", reason="With some reason message.")
+        def simple_addition(a=1, b=1):
+            return a + b
+
+        warn_msg_expected = (
+            "Keyword argument 'a' in 'simple_addition' is deprecated and will be removed in future release 1.3.0."
+            "\nWith some reason message."
+        )
+
+        simple_addition()
+        warn_obj = recwarn.pop(DeprecationWarning)
+        assert str(warn_obj.message) == warn_msg_expected
+
+    def test_deprecated_replaced_by_keyword(self, recwarn):
+        @deprecated_keyword_arg("b", "1.3.0", replaced_by="c")
+        def simple_addition(a=1, b=1):
+            return a + b
+
+        warn_msg_expected = (
+            "Keyword argument 'b' in 'simple_addition' is deprecated and will be removed in future release 1.3.0."
+            " It will be replaced by 'c'."
+        )
+
+        simple_addition(a=1, b=1)
+        warn_obj = recwarn.pop(DeprecationWarning)
+        assert str(warn_obj.message) == warn_msg_expected
+
+
+if __name__ == "__main__":
+    pytest.cmdline.main("-q -s {} --mlFramework=tensorflow --durations=0".format(__file__).split(" "))


### PR DESCRIPTION
# Description

Add deprecation decorators to ART. This will make it easier to deprecate functions, methods and keyword arguments.

Related to #423 

## Type of change

- [x] New feature (non-breaking)
- [x] This change requires a documentation update

# Testing

Several test cases for both decorators have been included.

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
