### PR TITLE
Deprecate channel_index in favor of channel_first

### DIFF
--- a/art/attacks/evasion/boundary.py
+++ b/art/attacks/evasion/boundary.py
@@ -314,13 +314,14 @@ class BoundaryAttack(EvasionAttack):
         direction = original_sample - current_sample
 
         if len(self.estimator.input_shape) == 3:
-            perturb = np.swapaxes(perturb, 0, self.estimator.channel_index - 1)
-            direction = np.swapaxes(direction, 0, self.estimator.channel_index - 1)
+            channel_index = 1 if self.estimator.channels_first else 3
+            perturb = np.swapaxes(perturb, 0, channel_index - 1)
+            direction = np.swapaxes(direction, 0, channel_index - 1)
             for i in range(direction.shape[0]):
                 direction[i] /= np.linalg.norm(direction[i])
                 perturb[i] -= np.dot(np.dot(perturb[i], direction[i].T), direction[i])
 
-            perturb = np.swapaxes(perturb, 0, self.estimator.channel_index - 1)
+            perturb = np.swapaxes(perturb, 0, channel_index - 1)
         elif len(self.estimator.input_shape) == 1:
             direction /= np.linalg.norm(direction)
             perturb -= np.dot(perturb, direction.T) * direction

--- a/art/attacks/evasion/pixel_threshold.py
+++ b/art/attacks/evasion/pixel_threshold.py
@@ -86,7 +86,7 @@ class PixelThreshold(EvasionAttack):
         PixelThreshold.set_params(self, **kwargs)
         self.type_attack = -1
 
-        if self.estimator.channel_index == 1:
+        if self.estimator.channels_first:
             self.img_rows = self.estimator.input_shape[-2]
             self.img_cols = self.estimator.input_shape[-1]
             self.img_channels = self.estimator.input_shape[-3]
@@ -311,7 +311,7 @@ class PixelAttack(PixelThreshold):
         for adv, image in zip(x, imgs):
             for pixel in np.split(adv, len(adv) // (2 + self.img_channels)):
                 x_pos, y_pos, *rgb = pixel
-                if self.estimator.channel_index == 3:
+                if not self.estimator.channels_first:
                     image[x_pos % self.img_rows, y_pos % self.img_cols] = rgb
                 else:
                     image[:, x_pos % self.img_rows, y_pos % self.img_cols] = rgb
@@ -326,7 +326,7 @@ class PixelAttack(PixelThreshold):
             for count, (i, j) in enumerate(product(range(self.img_rows), range(self.img_cols))):
                 initial += [i, j]
                 for k in range(self.img_channels):
-                    if self.estimator.channel_index == 3:
+                    if not self.estimator.channels_first:
                         initial += [img[i, j, k]]
                     else:
                         initial += [img[k, i, j]]

--- a/art/attacks/evasion/spatial_transformation.py
+++ b/art/attacks/evasion/spatial_transformation.py
@@ -171,14 +171,14 @@ class SpatialTransformation(EvasionAttack):
         return x_adv
 
     def _perturb(self, x, trans_x, trans_y, rot):
-        if self.estimator.channel_index == 3:
+        if not self.estimator.channels_first:
             x_adv = shift(x, [0, trans_x, trans_y, 0])
             x_adv = rotate(x_adv, angle=rot, axes=(1, 2), reshape=False)
-        elif self.estimator.channel_index == 1:
+        elif self.estimator.channels_first:
             x_adv = shift(x, [0, 0, trans_x, trans_y])
             x_adv = rotate(x_adv, angle=rot, axes=(2, 3), reshape=False)
         else:
-            raise ValueError("Unsupported channel index.")
+            raise ValueError("Unsupported channel_first value.")
 
         if self.estimator.clip_values is not None:
             np.clip(x_adv, self.estimator.clip_values[0], self.estimator.clip_values[1], out=x_adv)

--- a/art/defences/detector/evasion/detector.py
+++ b/art/defences/detector/evasion/detector.py
@@ -25,8 +25,16 @@ import logging
 
 import six
 
-from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
-from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
+from art.estimators.classification.classifier import (
+    ClassGradientsMixin,
+    ClassifierMixin,
+)
+from art.estimators.estimator import (
+    BaseEstimator,
+    LossGradientsMixin,
+    NeuralNetworkMixin,
+)
+from art.utils import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +55,7 @@ class BinaryInputDetector(ClassGradientsMixin, ClassifierMixin, LossGradientsMix
         super(BinaryInputDetector, self).__init__(
             clip_values=detector.clip_values,
             channel_index=detector.channel_index,
+            channels_first=detector.channels_first,
             preprocessing_defences=detector.preprocessing_defences,
             preprocessing=detector.preprocessing,
         )
@@ -105,8 +114,17 @@ class BinaryInputDetector(ClassGradientsMixin, ClassifierMixin, LossGradientsMix
         return self.detector.clip_values
 
     @property
+    @deprecated(end_version="1.5.0", replaced_by="channels_first")
     def channel_index(self):
         return self.detector.channel_index
+
+    @property
+    def channels_first(self):
+        """
+        :return: Boolean to indicate index of the color channels in the sample `x`.
+        :type: `bool`
+        """
+        return self._channels_first
 
     @property
     def learning_phase(self):

--- a/art/defences/detector/evasion/subsetscanning/detector.py
+++ b/art/defences/detector/evasion/subsetscanning/detector.py
@@ -29,6 +29,7 @@ import six
 
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin, LossGradientsMixin
 from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
+from art.utils import deprecated
 
 from art.defences.detector.evasion import Scanner
 
@@ -58,6 +59,7 @@ class SubsetScanningDetector(
         super(SubsetScanningDetector, self).__init__(
             clip_values=classifier.clip_values,
             channel_index=classifier.channel_index,
+            channels_first=classifier.channels_first,
             preprocessing_defences=classifier.preprocessing_defences,
             preprocessing=classifier.preprocessing,
         )
@@ -217,8 +219,17 @@ class SubsetScanningDetector(
         return self.detector.clip_values
 
     @property
+    @deprecated(end_version="1.5.0", replaced_by="channels_first")
     def channel_index(self):
         return self.detector.channel_index
+
+    @property
+    def channels_first(self):
+        """
+        :return: Boolean to indicate index of the color channels in the sample `x`.
+        :type: `bool`
+        """
+        return self.channels_first
 
     @property
     def learning_phase(self):

--- a/art/estimators/classification/ensemble.py
+++ b/art/estimators/classification/ensemble.py
@@ -24,8 +24,9 @@ import logging
 
 import numpy as np
 
-from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin, LossGradientsMixin
-from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
+from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
+from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
+from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +37,13 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
     trained when the ensemble is created and no training procedures are provided through this class.
     """
 
+    @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
         self,
         classifiers,
         classifier_weights=None,
-        channel_index=3,
+        channel_index=Deprecated,
+        channels_first=False,
         clip_values=None,
         preprocessing_defences=None,
         postprocessing_defences=None,
@@ -57,6 +60,8 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
         :type classifier_weights: `list` or `np.ndarray` or `None`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
                features. If arrays are provided, each value will be considered the bound for a feature, thus
@@ -75,9 +80,18 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
         if preprocessing_defences is not None:
             raise NotImplementedError("Preprocessing is not applicable in this classifier.")
 
+        # Remove in 1.5.0
+        if channel_index == 3:
+            channels_first = False
+        elif channel_index == 1:
+            channels_first = True
+        elif channel_index is not Deprecated:
+            raise ValueError("Not a proper channel_index. Use channels_first.")
+
         super(EnsembleClassifier, self).__init__(
             clip_values=clip_values,
             channel_index=channel_index,
+            channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,
@@ -118,13 +132,13 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
             classifier_weights = np.ones(self._nb_classifiers) / self._nb_classifiers
         self._classifier_weights = classifier_weights
 
-        # check for consistent channel_index in ensemble members
+        # check for consistent channels_first in ensemble members
         for i_cls, cls in enumerate(classifiers):
-            if cls.channel_index != self.channel_index:
+            if cls.channels_first != self.channels_first:
                 raise ValueError(
-                    "The channel_index value of classifier {} is {} while this ensemble expects a "
-                    "channel_index value of {}. The channel_index values of all classifiers and the "
-                    "ensemble need ot be identical.".format(i_cls, cls.channel_index, self.channel_index)
+                    "The channels_first boolean of classifier {} is {} while this ensemble expects a "
+                    "channels_first boolean of {}. The channels_first booleans of all classifiers and the "
+                    "ensemble need ot be identical.".format(i_cls, cls.channels_first, self.channels_first)
                 )
 
         self._classifiers = classifiers
@@ -297,13 +311,14 @@ class EnsembleClassifier(ClassGradientsMixin, ClassifierMixin, LossGradientsMixi
 
     def __repr__(self):
         repr_ = (
-            "%s(classifiers=%r, classifier_weights=%r, channel_index=%r, clip_values=%r, "
+            "%s(classifiers=%r, classifier_weights=%r, channel_index=%r, channels_first=%r, clip_values=%r, "
             "preprocessing_defences=%r, postprocessing_defences=%r, preprocessing=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
                 self._classifiers,
                 self._classifier_weights,
                 self.channel_index,
+                self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,
                 self.postprocessing_defences,

--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -25,8 +25,9 @@ import logging
 import numpy as np
 import six
 
+from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
 from art.estimators.keras import KerasEstimator
-from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
+from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +37,13 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
     Wrapper class for importing Keras models. The supported backends for Keras are TensorFlow and Theano.
     """
 
+    @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
         self,
         model,
         use_logits=False,
-        channel_index=3,
+        channel_index=Deprecated,
+        channels_first=False,
         clip_values=None,
         preprocessing_defences=None,
         postprocessing_defences=None,
@@ -58,6 +61,8 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         :type use_logits: `bool`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
                features. If arrays are provided, each value will be considered the bound for a feature, thus
@@ -80,12 +85,21 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
                              layer this values is not required.
         :type output_layer: `int`
         """
+        # Remove in 1.5.0
+        if channel_index == 3:
+            channels_first = False
+        elif channel_index == 1:
+            channels_first = True
+        elif channel_index is not Deprecated:
+            raise ValueError("Not a proper channel_index. Use channels_first.")
+
         super(KerasClassifier, self).__init__(
             clip_values=clip_values,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,
             channel_index=channel_index,
+            channels_first=channels_first,
         )
 
         self._model = model
@@ -658,13 +672,14 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, use_logits=%r, channel_index=%r, clip_values=%r, preprocessing_defences=%r, "
-            "postprocessing_defences=%r, preprocessing=%r, input_layer=%r, output_layer=%r)"
+            "%s(model=%r, use_logits=%r, channel_index=%r, channels_first=%r, clip_values=%r, preprocessing_defences=%r"
+            ", postprocessing_defences=%r, preprocessing=%r, input_layer=%r, output_layer=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
                 self._model,
                 self._use_logits,
                 self.channel_index,
+                self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,
                 self.postprocessing_defences,

--- a/art/estimators/classification/mxnet.py
+++ b/art/estimators/classification/mxnet.py
@@ -26,8 +26,9 @@ import numpy as np
 import six
 
 from art.config import ART_NUMPY_DTYPE
+from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
 from art.estimators.mxnet import MXEstimator
-from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
+from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
     Wrapper class for importing MXNet Gluon models.
     """
 
+    @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
         self,
         model,
@@ -45,7 +47,8 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         nb_classes,
         optimizer=None,
         ctx=None,
-        channel_index=1,
+        channel_index=Deprecated,
+        channels_first=True,
         clip_values=None,
         preprocessing_defences=None,
         postprocessing_defences=None,
@@ -70,6 +73,8 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         :type ctx: `mxnet.context.Context`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
                features. If arrays are provided, each value will be considered the bound for a feature, thus
@@ -86,9 +91,18 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
         """
         import mxnet as mx
 
+        # Remove in 1.5.0
+        if channel_index == 3:
+            channels_first = False
+        elif channel_index == 1:
+            channels_first = True
+        elif channel_index is not Deprecated:
+            raise ValueError("Not a proper channel_index. Use channels_first.")
+
         super(MXClassifier, self).__init__(
             clip_values=clip_values,
             channel_index=channel_index,
+            channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,
@@ -481,8 +495,9 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, loss=%r, input_shape=%r, nb_classes=%r, optimizer=%r, ctx=%r, channel_index=%r, "
-            "clip_values=%r, preprocessing_defences=%r, postprocessing_defences=%r, preprocessing=%r)"
+            "%s(model=%r, loss=%r, input_shape=%r, nb_classes=%r, optimizer=%r, ctx=%r, channel_index=%r,"
+            " channels_first=%r, clip_values=%r, preprocessing_defences=%r, postprocessing_defences=%r,"
+            " preprocessing=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
                 self._model,
@@ -492,6 +507,7 @@ class MXClassifier(ClassGradientsMixin, ClassifierMixin, MXEstimator):  # lgtm [
                 self._optimizer,
                 self._ctx,
                 self.channel_index,
+                self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,
                 self.postprocessing_defences,

--- a/art/estimators/classification/pytorch.py
+++ b/art/estimators/classification/pytorch.py
@@ -26,8 +26,9 @@ import random
 import numpy as np
 import six
 
+from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
 from art.estimators.pytorch import PyTorchEstimator
-from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
+from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
     This class implements a classifier with the PyTorch framework.
     """
 
+    @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
         self,
         model,
@@ -44,7 +46,8 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         input_shape,
         nb_classes,
         optimizer=None,
-        channel_index=1,
+        channel_index=Deprecated,
+        channels_first=True,
         clip_values=None,
         preprocessing_defences=None,
         postprocessing_defences=None,
@@ -68,6 +71,8 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         :type optimizer: `torch.optim.Optimizer`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
         :param clip_values: Tuple of the form `(min, max)` of floats or `np.ndarray` representing the minimum and
                maximum values allowed for features. If floats are provided, these will be used as the range of all
                features. If arrays are provided, each value will be considered the bound for a feature, thus
@@ -84,14 +89,22 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
         :param device_type: Type of device on which the classifier is run, either `gpu` or `cpu`.
         :type device_type: `string`
         """
+        # Remove in 1.5.0
+        if channel_index == 3:
+            channels_first = False
+        elif channel_index == 1:
+            channels_first = True
+        elif channel_index is not Deprecated:
+            raise ValueError("Not a proper channel_index. Use channels_first.")
+
         super().__init__(
             clip_values=clip_values,
             channel_index=channel_index,
+            channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,
         )
-
         self._nb_classes = nb_classes
         self._input_shape = input_shape
         self._model = self._make_model_wrapper(model)
@@ -588,7 +601,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
 
     def __repr__(self):
         repr_ = (
-            "%s(model=%r, loss=%r, optimizer=%r, input_shape=%r, nb_classes=%r, channel_index=%r, "
+            "%s(model=%r, loss=%r, optimizer=%r, input_shape=%r, nb_classes=%r, channel_index=%r, channels_first=%r, "
             "clip_values=%r, preprocessing_defences=%r, postprocessing_defences=%r, preprocessing=%r)"
             % (
                 self.__module__ + "." + self.__class__.__name__,
@@ -598,6 +611,7 @@ class PyTorchClassifier(ClassGradientsMixin, ClassifierMixin, PyTorchEstimator):
                 self._input_shape,
                 self.nb_classes,
                 self.channel_index,
+                self.channels_first,
                 self.clip_values,
                 self.preprocessing_defences,
                 self.postprocessing_defences,

--- a/art/estimators/estimator.py
+++ b/art/estimators/estimator.py
@@ -24,8 +24,9 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 from art.config import ART_NUMPY_DTYPE
-from art.defences.preprocessor.preprocessor import Preprocessor
 from art.defences.postprocessor.postprocessor import Postprocessor
+from art.defences.preprocessor.preprocessor import Preprocessor
+from art.utils import Deprecated, deprecated, deprecated_keyword_arg
 
 
 class BaseEstimator(ABC):
@@ -408,14 +409,26 @@ class NeuralNetworkMixin(ABC):
     has to be mixed in with class `BaseEstimator`.
     """
 
-    def __init__(self, channel_index=None, **kwargs):
+    @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
+    def __init__(self, channel_index=Deprecated, channels_first=None, **kwargs):
         """
         Initialize a neural network attributes.
 
         :param channel_index: Index of the axis in samples `x` representing the color channels.
         :type channel_index: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
         """
+        # Remove in 1.5.0
+        if channel_index == 3:
+            channels_first = False
+        elif channel_index == 1:
+            channels_first = True
+        elif channel_index is not Deprecated:
+            raise ValueError("Not a proper channel_index. Use channels_first.")
+
         self._channel_index = channel_index
+        self._channels_first = channels_first
         super().__init__(**kwargs)
 
     @abstractmethod
@@ -508,12 +521,21 @@ class NeuralNetworkMixin(ABC):
         raise NotImplementedError
 
     @property
+    @deprecated(end_version="1.5.0", replaced_by="channels_first")
     def channel_index(self):
         """
         :return: Index of the axis containing the color channels in the samples `x`.
         :rtype: `int`
         """
         return self._channel_index
+
+    @property
+    def channels_first(self):
+        """
+        :return: Boolean to indicate index of the color channels in the sample `x`.
+        :type: `bool`
+        """
+        return self._channels_first
 
     @property
     def learning_phase(self):

--- a/art/estimators/object_detection/PyTorchFasterRCNN.py
+++ b/art/estimators/object_detection/PyTorchFasterRCNN.py
@@ -22,8 +22,9 @@ import logging
 
 import numpy as np
 
-from art.estimators.pytorch import PyTorchEstimator
 from art.estimators.object_detection.object_detector import ObjectDetectorMixin
+from art.estimators.pytorch import PyTorchEstimator
+from art.utils import Deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +34,13 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
     This class implements a model-specific object detector using Faster-RCNN and PyTorch.
     """
 
+    @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
         self,
         model=None,
         clip_values=None,
-        channel_index=None,
+        channel_index=Deprecated,
+        channels_first=None,
         preprocessing_defences=None,
         postprocessing_defences=None,
         preprocessing=None,
@@ -61,6 +64,8 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
         :type clip_values: `tuple`
         :param channel_index: Index of the axis in data containing the color channels or features.
         :type channel_index: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
         :param preprocessing_defences: Preprocessing defence(s) to be applied by the classifier.
         :type preprocessing_defences: :class:`.Preprocessor` or `list(Preprocessor)` instances
         :param postprocessing_defences: Postprocessing defence(s) to be applied by the classifier.
@@ -76,10 +81,18 @@ class PyTorchFasterRCNN(ObjectDetectorMixin, PyTorchEstimator):
                             if available otherwise run on CPU.
         :type device_type: `string`
         """
+        # Remove in 1.5.0
+        if channel_index == 3:
+            channels_first = False
+        elif channel_index == 1:
+            channels_first = True
+        elif channel_index is not Deprecated:
+            raise ValueError("Not a proper channel_index. Use channels_first.")
 
         super().__init__(
             clip_values=clip_values,
             channel_index=channel_index,
+            channels_first=channels_first,
             preprocessing_defences=preprocessing_defences,
             postprocessing_defences=postprocessing_defences,
             preprocessing=preprocessing,

--- a/conftest.py
+++ b/conftest.py
@@ -86,7 +86,7 @@ def get_tabular_classifier_list(framework):
                 classifier_list = [get_tabular_classifier_kr()]
             else:
                 classifier = get_tabular_classifier_kr()
-                classifier_list = [KerasClassifier(model=classifier.model, use_logits=False, channel_index=1)]
+                classifier_list = [KerasClassifier(model=classifier.model, use_logits=False, channels_first=True)]
 
         if framework == "tensorflow":
             if clipped:

--- a/examples/get_started_mxnet.py
+++ b/examples/get_started_mxnet.py
@@ -47,7 +47,7 @@ classifier = MXClassifier(
     nb_classes=10,
     optimizer=trainer,
     ctx=None,
-    channel_index=1,
+    channels_first=True,
     preprocessing_defences=None,
     preprocessing=(0, 1),
 )

--- a/notebooks/adaptive_defence_evaluations/evaluation_12_EMPIR.ipynb
+++ b/notebooks/adaptive_defence_evaluations/evaluation_12_EMPIR.ipynb
@@ -345,7 +345,7 @@
     "                                        loss=loss,\n",
     "                                        learning=phase,\n",
     "                                        sess=sess,\n",
-    "                                        channel_index=3,\n",
+    "                                        channels_first=False,\n",
     "                                        clip_values=(0, 1),\n",
     "                                        preprocessing=(0, 1),\n",
     "                                        feed_dict=feed_dict)"
@@ -471,7 +471,7 @@
     "                                       loss=loss_new,\n",
     "                                       learning=phase,\n",
     "                                       sess=sess,\n",
-    "                                       channel_index=3,\n",
+    "                                       channels_first=False,\n",
     "                                       clip_values=(0, 1),\n",
     "                                       preprocessing=(0, 1),\n",
     "                                       feed_dict=feed_dict)"
@@ -600,7 +600,7 @@
     "                                             loss=loss_i,\n",
     "                                             learning=phase,\n",
     "                                             sess=sess,\n",
-    "                                             channel_index=3,\n",
+    "                                             channels_first=False,\n",
     "                                             clip_values=(0, 1),\n",
     "                                             preprocessing=(0, 1),\n",
     "                                             feed_dict=feed_dict)\n",
@@ -632,9 +632,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv36_TF1_14_keras225",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "venv36_tf1_14_keras225"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -646,7 +646,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/adversarial_action_recognition.ipynb
+++ b/notebooks/adversarial_action_recognition.ipynb
@@ -216,7 +216,7 @@
     "    nb_classes=101,\n",
     "    preprocessing=(mean, std),\n",
     "    clip_values=(0, 1),\n",
-    "    channel_index=1,\n",
+    "    channels_first=True,\n",
     ")"
    ]
   },
@@ -467,7 +467,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/adversarial_audio_examples.ipynb
+++ b/notebooks/adversarial_audio_examples.ipynb
@@ -731,7 +731,7 @@
    ],
    "source": [
     "# initialize Mp3Compression defense\n",
-    "mp3_compression = Mp3Compression(sample_rate=DOWNSAMPLED_SAMPLING_RATE, channel_index=1)\n",
+    "mp3_compression = Mp3Compression(sample_rate=DOWNSAMPLED_SAMPLING_RATE, channels_first=True)\n",
     "\n",
     "# load a test sample\n",
     "sample = audiomnist_test[1021]\n",

--- a/notebooks/art-for-tensorflow-v2-callable.ipynb
+++ b/notebooks/art-for-tensorflow-v2-callable.ipynb
@@ -314,7 +314,7 @@
    "outputs": [],
    "source": [
     "classifier = TensorFlowV2Classifier(model=model, nb_classes=10, input_shape=(28, 28, 1), loss_object=loss_object, \n",
-    "                                    clip_values=(0, 1), channel_index=3)"
+    "                                    clip_values=(0, 1), channels_first=False)"
    ]
   },
   {
@@ -721,7 +721,7 @@
    "outputs": [],
    "source": [
     "classifier = TensorFlowV2Classifier(model=forward, nb_classes=10, input_shape=(28, 28, 1),\n",
-    "                                    loss_object=loss_object, clip_values=(0, 1), channel_index=3)"
+    "                                    loss_object=loss_object, clip_values=(0, 1), channels_first=False)"
    ]
   },
   {
@@ -974,9 +974,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv36_TF210_keras231",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "venv36_tf210_keras231"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -988,7 +988,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/classifier_blackbox_tesseract.ipynb
+++ b/notebooks/classifier_blackbox_tesseract.ipynb
@@ -324,7 +324,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jpeg = JpegCompression(clip_values=(0, 255), channel_index=3)\n",
+    "jpeg = JpegCompression(clip_values=(0, 255), channels_first=False)\n",
     "classifier_def = BlackBoxClassifier(predict, image_target.shape, 3, clip_values=(0, 255),\n",
     "                                    preprocessing_defences=[jpeg])"
    ]
@@ -548,9 +548,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv36_TF210_keras231",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "venv36_tf210_keras231"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -562,7 +562,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/tests/attacks/evasion/test_dpatch.py
+++ b/tests/attacks/evasion/test_dpatch.py
@@ -16,15 +16,15 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import logging
+
 import numpy as np
 import pytest
 
 from art.attacks.evasion import DPatch
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin
 from art.estimators.object_detection.object_detector import ObjectDetectorMixin
-
-from tests.utils import master_seed
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import master_seed
 
 logger = logging.getLogger(__name__)
 
@@ -47,14 +47,14 @@ def test_augment_images_with_patch(random_location, image_format, fix_get_mnist_
     if image_format == "NHWC":
         patch = np.ones(shape=(4, 4, 1)) * 0.5
         x = x_train_mnist[0:3]
-        channel_index = 3
+        channels_first = False
     elif image_format == "NCHW":
         patch = np.ones(shape=(1, 4, 4)) * 0.5
         x = np.transpose(x_train_mnist[0:3], (0, 3, 1, 2))
-        channel_index = 1
+        channels_first = True
 
     patched_images, transformations = DPatch._augment_images_with_patch(
-        x=x, patch=patch, random_location=random_location, channel_index=channel_index
+        x=x, patch=patch, random_location=random_location, channels_first=channels_first
     )
 
     if random_location:

--- a/tests/attacks/test_carlini.py
+++ b/tests/attacks/test_carlini.py
@@ -227,7 +227,7 @@ class TestCarlini(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = CarliniL2Method(classifier, targeted=False, max_iter=10)
         x_test_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_adv).all())
@@ -485,7 +485,7 @@ class TestCarlini(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = CarliniLInfMethod(classifier, targeted=False, max_iter=10, eps=1)
         x_test_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_adv).all())

--- a/tests/attacks/test_copycat_cnn.py
+++ b/tests/attacks/test_copycat_cnn.py
@@ -20,24 +20,30 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import unittest
 
-import tensorflow as tf
-import numpy as np
 import keras
 import keras.backend as k
-from keras.models import Sequential
-from keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
+import numpy as np
+import tensorflow as tf
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
+from keras.models import Sequential
 
 from art.attacks.extraction.copycat_cnn import CopycatCNN
-from art.estimators.classification.tensorflow import TensorFlowClassifier
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.classification.pytorch import PyTorchClassifier
-
-from tests.utils import TestBase, master_seed
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
+from art.estimators.classification.tensorflow import TensorFlowClassifier
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+    master_seed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +273,7 @@ class TestCopycatCNNVectors(TestBase):
             loss=loss,
             learning=None,
             sess=sess,
-            channel_index=1,
+            channels_first=True,
         )
 
         # Create attack
@@ -307,7 +313,7 @@ class TestCopycatCNNVectors(TestBase):
         model.compile(loss="categorical_crossentropy", optimizer=keras.optimizers.Adam(lr=0.001), metrics=["accuracy"])
 
         # Get classifier
-        thieved_krc = KerasClassifier(model, clip_values=(0, 1), use_logits=False, channel_index=1)
+        thieved_krc = KerasClassifier(model, clip_values=(0, 1), use_logits=False, channels_first=True)
 
         # Create attack
         copycat_cnn = CopycatCNN(
@@ -372,7 +378,7 @@ class TestCopycatCNNVectors(TestBase):
             input_shape=(4,),
             nb_classes=3,
             clip_values=(0, 1),
-            channel_index=1,
+            channels_first=True,
         )
 
         # Create attack

--- a/tests/attacks/test_deepfool.py
+++ b/tests/attacks/test_deepfool.py
@@ -19,18 +19,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+
 import keras
 import numpy as np
 
 from art.attacks.evasion.deepfool import DeepFool
-from art.estimators.classification.keras import KerasClassifier
 from art.estimators.classification.classifier import ClassGradientsMixin
+from art.estimators.classification.keras import KerasClassifier
 from art.utils import get_labels_np_array
-
-from tests.utils import TestBase
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +211,7 @@ class TestDeepFool(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = DeepFool(classifier, max_iter=5, batch_size=128)
         x_test_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_adv).all())

--- a/tests/attacks/test_elastic_net.py
+++ b/tests/attacks/test_elastic_net.py
@@ -19,19 +19,25 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+
 import keras.backend as k
 import numpy as np
 
 from art.attacks.evasion.elastic_net import ElasticNet
-from art.estimators.classification.keras import KerasClassifier
 from art.estimators.classification.classifier import ClassGradientsMixin
+from art.estimators.classification.keras import KerasClassifier
 from art.utils import random_targets, to_categorical
-
-from tests.utils import TestBase, master_seed
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr
-from tests.utils import get_image_classifier_pt, get_tabular_classifier_tf
-from tests.utils import get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+    master_seed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -473,7 +479,7 @@ class TestElasticNet(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = ElasticNet(classifier, targeted=False, max_iter=10)
         x_test_adv = attack.generate(self.x_test_iris)
         expected_x_test_adv = np.asarray([0.85931635, 0.44633555, 0.65658355, 0.23840423])

--- a/tests/attacks/test_hop_skip_jump.py
+++ b/tests/attacks/test_hop_skip_jump.py
@@ -310,7 +310,7 @@ class TestHopSkipJump(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
 
         # Norm=2
         attack = HopSkipJump(classifier, targeted=False, max_iter=2, max_eval=100, init_eval=10)

--- a/tests/attacks/test_input_filter.py
+++ b/tests/attacks/test_input_filter.py
@@ -166,7 +166,7 @@ class TestInputFilter(unittest.TestCase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = ProjectedGradientDescent(classifier, eps=1, eps_step=0.2, max_iter=5)
         x_test_adv = attack.generate(x_test)
         self.assertFalse((np.array(x_test) == x_test_adv).all())

--- a/tests/attacks/test_iterative_method.py
+++ b/tests/attacks/test_iterative_method.py
@@ -19,17 +19,23 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+
 import numpy as np
 
 from art.attacks.evasion.iterative_method import BasicIterativeMethod
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin
 from art.utils import get_labels_np_array, random_targets
-
-from tests.utils import TestBase
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +191,7 @@ class TestIterativeAttack(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = BasicIterativeMethod(classifier, eps=1, eps_step=0.2, batch_size=128)
         x_test_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_adv).all())

--- a/tests/attacks/test_newtonfool.py
+++ b/tests/attacks/test_newtonfool.py
@@ -23,14 +23,19 @@ import unittest
 import numpy as np
 
 from art.attacks.evasion.newtonfool import NewtonFool
+from art.estimators.classification.classifier import ClassGradientsMixin
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.estimator import BaseEstimator
-from art.estimators.classification.classifier import ClassGradientsMixin
-
-from tests.utils import TestBase
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +146,7 @@ class TestNewtonFool(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = NewtonFool(classifier, max_iter=5, batch_size=128)
         x_test_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_adv).all())

--- a/tests/attacks/test_projected_gradient_descent.py
+++ b/tests/attacks/test_projected_gradient_descent.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+
 import numpy as np
 import tensorflow as tf
 
@@ -26,15 +27,20 @@ from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent i
 from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent_numpy import (
     ProjectedGradientDescentNumpy,
 )
-from art.estimators.estimator import BaseEstimator, LossGradientsMixin
 from art.estimators.classification import KerasClassifier
+from art.estimators.estimator import BaseEstimator, LossGradientsMixin
 from art.utils import get_labels_np_array, random_targets
-
-from tests.utils import master_seed
-from tests.utils import TestBase
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+    master_seed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +189,7 @@ class TestPGD(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = ProjectedGradientDescent(classifier, eps=1, eps_step=0.2, max_iter=5)
         x_test_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_adv).all())

--- a/tests/attacks/test_saliency_map.py
+++ b/tests/attacks/test_saliency_map.py
@@ -19,18 +19,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+
 import numpy as np
 
 from art.attacks.evasion.saliency_map import SaliencyMapMethod
+from art.estimators.classification.classifier import ClassGradientsMixin
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.estimator import BaseEstimator
-from art.estimators.classification.classifier import ClassGradientsMixin
 from art.utils import get_labels_np_array, to_categorical
-
-from tests.utils import TestBase
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +222,7 @@ class TestSaliencyMap(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = SaliencyMapMethod(classifier, theta=1)
         x_test_iris_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_iris_adv).all())

--- a/tests/attacks/test_universal_perturbation.py
+++ b/tests/attacks/test_universal_perturbation.py
@@ -19,17 +19,23 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import unittest
+
 import numpy as np
 
 from art.attacks.evasion.universal_perturbation import UniversalPerturbation
+from art.estimators.classification.classifier import ClassGradientsMixin
 from art.estimators.classification.keras import KerasClassifier
 from art.estimators.estimator import BaseEstimator, NeuralNetworkMixin
-from art.estimators.classification.classifier import ClassGradientsMixin
-
-from tests.utils import TestBase
-from tests.utils import get_image_classifier_tf, get_image_classifier_kr, get_image_classifier_pt
-from tests.utils import get_tabular_classifier_tf, get_tabular_classifier_kr, get_tabular_classifier_pt
 from tests.attacks.utils import backend_test_classifier_type_check_fail
+from tests.utils import (
+    TestBase,
+    get_image_classifier_kr,
+    get_image_classifier_pt,
+    get_image_classifier_tf,
+    get_tabular_classifier_kr,
+    get_tabular_classifier_pt,
+    get_tabular_classifier_tf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +157,7 @@ class TestUniversalPerturbation(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack_params = {"max_iter": 1, "attacker": "newtonfool", "attacker_params": {"max_iter": 5}}
         attack = UniversalPerturbation(classifier)
         attack.set_params(**attack_params)

--- a/tests/attacks/test_virtual_adversarial.py
+++ b/tests/attacks/test_virtual_adversarial.py
@@ -122,7 +122,7 @@ class TestVirtualAdversarial(TestBase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         attack = VirtualAdversarialMethod(classifier, eps=1)
         x_test_iris_adv = attack.generate(self.x_test_iris)
         self.assertFalse((self.x_test_iris == x_test_iris_adv).all())

--- a/tests/classifiersFrameworks/test_keras.py
+++ b/tests/classifiersFrameworks/test_keras.py
@@ -15,33 +15,32 @@
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import os
 import logging
+import os
 
-import pytest
-import numpy as np
 import keras
-from keras.layers import Dense, Conv2D, MaxPooling2D, Dropout, Input, Flatten
-from keras.models import Model
-from keras.preprocessing.image import ImageDataGenerator
-from keras.callbacks import LearningRateScheduler
+import numpy as np
+import pytest
 from keras.applications.resnet50 import ResNet50, decode_predictions
-from keras.preprocessing.image import load_img, img_to_array
+from keras.callbacks import LearningRateScheduler
+from keras.layers import Conv2D, Dense, Dropout, Flatten, Input, MaxPooling2D
+from keras.models import Model
+from keras.preprocessing.image import ImageDataGenerator, img_to_array, load_img
 
-from art.estimators.classification.keras import KerasClassifier, generator_fit
-from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
 from art.data_generators import KerasDataGenerator
-
-from tests.utils import ExpectedValue
+from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
+from art.estimators.classification.keras import KerasClassifier, generator_fit
+from art.utils import Deprecated
 from tests.classifiersFrameworks.utils import (
-    backend_test_nb_classes,
-    backend_test_input_shape,
-    backend_test_fit_generator,
-    backend_test_loss_gradient,
-    backend_test_layers,
     backend_test_class_gradient,
+    backend_test_fit_generator,
+    backend_test_input_shape,
+    backend_test_layers,
+    backend_test_loss_gradient,
+    backend_test_nb_classes,
     backend_test_repr,
 )
+from tests.utils import ExpectedValue
 
 logger = logging.getLogger(__name__)
 
@@ -725,8 +724,9 @@ def test_repr(get_image_classifier_list):
         get_image_classifier_list(),
         [
             "art.estimators.classification.keras.KerasClassifier",
-            "use_logits=False, channel_index=3",
-            "clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, " "postprocessing_defences=None, "
+            f"use_logits=False, channel_index={Deprecated}, channels_first=False",
+            "clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, "
+            "postprocessing_defences=None, "
             "preprocessing=(0, 1)",
             "input_layer=0, output_layer=0",
         ],

--- a/tests/classifiersFrameworks/test_tensorflow.py
+++ b/tests/classifiersFrameworks/test_tensorflow.py
@@ -17,19 +17,24 @@
 # SOFTWARE.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import pytest
 import logging
 
-import tensorflow as tf
 import numpy as np
+import pytest
+import tensorflow as tf
 
 from art.data_generators import TensorFlowDataGenerator
-
+from art.utils import Deprecated
+from tests.classifiersFrameworks.utils import (
+    backend_test_class_gradient,
+    backend_test_fit_generator,
+    backend_test_input_shape,
+    backend_test_layers,
+    backend_test_loss_gradient,
+    backend_test_nb_classes,
+    backend_test_repr,
+)
 from tests.utils import ExpectedValue
-from tests.classifiersFrameworks.utils import backend_test_layers, backend_test_repr
-from tests.classifiersFrameworks.utils import backend_test_loss_gradient, backend_test_class_gradient
-from tests.classifiersFrameworks.utils import backend_test_fit_generator, backend_test_nb_classes
-from tests.classifiersFrameworks.utils import backend_test_input_shape
 
 logger = logging.getLogger(__name__)
 
@@ -424,8 +429,8 @@ def test_repr(is_tf_version_2, get_image_classifier_list):
                 "input_shape=(28, 28, 1)",
                 "loss_object=<tensorflow.python.keras.losses." "SparseCategoricalCrossentropy",
                 "train_step=<function get_image_classifier_tf_v2." "<locals>.train_step",
-                "channel_index=3, clip_values=array([0., 1.], dtype=float32), preprocessing_defences="
-                "None, postprocessing_defences=None, preprocessing=(0, 1))",
+                f"channel_index={Deprecated}, channels_first=False, clip_values=array([0., 1.], dtype=float32), "
+                "preprocessing_defences=None, postprocessing_defences=None, preprocessing=(0, 1))",
             ],
         )
 
@@ -443,7 +448,7 @@ def test_repr(is_tf_version_2, get_image_classifier_list):
                 "learning=None",
                 "sess=<tensorflow.python.client.session.Session object",
                 "TensorFlowClassifier",
-                "channel_index=3, clip_values=array([0., 1.], dtype=float32), "
+                f"channel_index={Deprecated}, channels_first=False, clip_values=array([0., 1.], dtype=float32), "
                 "preprocessing_defences=None, postprocessing_defences=None, "
                 "preprocessing=(0, 1))",
             ],

--- a/tests/defences/detector/poison/test_activation_defence.py
+++ b/tests/defences/detector/poison/test_activation_defence.py
@@ -199,7 +199,7 @@ class TestActivationDefence(unittest.TestCase):
         loaded = ActivationDefence._unpickle_classifier(filename)
 
         np.testing.assert_equal(self.classifier._clip_values, loaded._clip_values)
-        self.assertEqual(self.classifier._channel_index, loaded._channel_index)
+        self.assertEqual(self.classifier._channels_first, loaded._channels_first)
         self.assertEqual(self.classifier._use_logits, loaded._use_logits)
         self.assertEqual(self.classifier._input_layer, loaded._input_layer)
 

--- a/tests/defences/preprocessor/test_jpeg_compression.py
+++ b/tests/defences/preprocessor/test_jpeg_compression.py
@@ -85,17 +85,15 @@ class TestJpegCompression:
 
     @pytest.mark.parametrize("channels_first", [True, False])
     def test_jpeg_compression_image_data(self, image_batch, channels_first):
-        channel_index = 1 if channels_first else 3
         test_input, test_output = image_batch
-        jpeg_compression = JpegCompression(clip_values=(0, 255), channel_index=channel_index)
+        jpeg_compression = JpegCompression(clip_values=(0, 255), channels_first=channels_first)
 
         assert_array_equal(jpeg_compression(test_input)[0], test_output)
 
     @pytest.mark.parametrize("channels_first", [True, False])
     def test_jpeg_compression_video_data(self, video_batch, channels_first):
-        channel_index = 1 if channels_first else 4
         test_input, test_output = video_batch
-        jpeg_compression = JpegCompression(clip_values=(0, 255), channel_index=channel_index)
+        jpeg_compression = JpegCompression(clip_values=(0, 255), channels_first=channels_first)
 
         assert_array_equal(jpeg_compression(test_input)[0], test_output)
 
@@ -110,28 +108,23 @@ class TestJpegCompression:
 
         assert_array_equal(jpeg_compression._compress(test_single_input, image_mode), test_single_output)
 
-    def test_channel_index_error(self):
-        exc_msg = "Data channel must be an integer equal to 1, 3 or 4. The batch dimension is not a valid channel."
-        with pytest.raises(ValueError, match=exc_msg):
-            JpegCompression(clip_values=(0, 255), channel_index=0)
-
     def test_non_spatial_data_error(self, tabular_batch):
         test_input = tabular_batch
-        jpeg_compression = JpegCompression(clip_values=(0, 255), channel_index=1)
+        jpeg_compression = JpegCompression(clip_values=(0, 255), channels_first=True)
 
-        exc_msg = "Feature vectors detected. JPEG compression can only be applied to data with spatial dimensions."
+        exc_msg = "Unrecognized input dimension. JPEG compression can only be applied to image and video data."
         with pytest.raises(ValueError, match=exc_msg):
             jpeg_compression(test_input)
 
     def test_negative_clip_values_error(self):
         exc_msg = "'clip_values' min value must be 0."
         with pytest.raises(ValueError, match=exc_msg):
-            JpegCompression(clip_values=(-1, 255), channel_index=1)
+            JpegCompression(clip_values=(-1, 255), channels_first=True)
 
     def test_maximum_clip_values_error(self):
         exc_msg = "'clip_values' max value must be either 1 or 255."
         with pytest.raises(ValueError, match=exc_msg):
-            JpegCompression(clip_values=(0, 2), channel_index=1)
+            JpegCompression(clip_values=(0, 2), channels_first=True)
 
 
 if __name__ == "__main__":

--- a/tests/defences/preprocessor/test_mp3_compression.py
+++ b/tests/defences/preprocessor/test_mp3_compression.py
@@ -33,30 +33,26 @@ class AudioInput:
     Create audio batch.
     """
 
-    def __init__(self, channel_index, channels, sample_rate=44100, batch_size=2):
-        self.channel_index = channel_index
+    def __init__(self, channels_first, channels, sample_rate=44100, batch_size=2):
+        self.channels_first = channels_first
         self.channels = channels
         self.sample_rate = sample_rate
         self.batch_size = batch_size
 
     def get_data(self):
-        if self.channel_index == 1:
-            return np.zeros(
-                (self.batch_size, self.channels, self.sample_rate), dtype=np.int16
-            )
+        if self.channels_first:
+            return np.zeros((self.batch_size, self.channels, self.sample_rate), dtype=np.int16)
         else:
-            return np.zeros(
-                (self.batch_size, self.sample_rate, self.channels), dtype=np.int16
-            )
+            return np.zeros((self.batch_size, self.sample_rate, self.channels), dtype=np.int16)
 
 
 @pytest.fixture(params=[1, 2], ids=["mono", "stereo"])
-def audio_batch(request, channel_index):
+def audio_batch(request, channels_first):
     """
     Audio fixtures of shape `(batch_size, channels, samples)` or `(batch_size, samples, channels)`.
     """
     channels = request.param
-    audio_input = AudioInput(channel_index, channels)
+    audio_input = AudioInput(channels_first, channels)
     test_input = audio_input.get_data()
     test_output = test_input.copy()
     return test_input, test_output, audio_input.sample_rate
@@ -71,30 +67,23 @@ def image_batch():
 class TestMp3Compression:
     """Test Mp3Compresssion."""
 
-    def test_channel_index_error(self):
-        exc_msg = "Data channel must be an integer equal to 1 or 2. The batch dimension is not a valid channel."
-        with pytest.raises(ValueError, match=exc_msg):
-            Mp3Compression(sample_rate=16000, channel_index=3)
-
     def test_sample_rate_error(self):
         exc_msg = "Sample rate be must a positive integer."
         with pytest.raises(ValueError, match=exc_msg):
-            Mp3Compression(sample_rate=0, channel_index=1)
+            Mp3Compression(sample_rate=0)
 
     def test_non_temporal_data_error(self, image_batch):
         test_input = image_batch
-        mp3compression = Mp3Compression(sample_rate=16000, channel_index=1)
+        mp3compression = Mp3Compression(sample_rate=16000)
 
         exc_msg = "Mp3 compression can only be applied to temporal data across at least one channel."
         with pytest.raises(ValueError, match=exc_msg):
             mp3compression(test_input)
 
-    @pytest.mark.parametrize("channel_index", [1, 2])
-    def test_mp3_compresssion(self, audio_batch, channel_index):
+    @pytest.mark.parametrize("channels_first", [True, False])
+    def test_mp3_compresssion(self, audio_batch, channels_first):
         test_input, test_output, sample_rate = audio_batch
-        mp3compression = Mp3Compression(
-            sample_rate=sample_rate, channel_index=channel_index
-        )
+        mp3compression = Mp3Compression(sample_rate=sample_rate, channels_first=channels_first)
 
         assert_array_equal(mp3compression(test_input), test_output)
 

--- a/tests/defences/preprocessor/test_resample.py
+++ b/tests/defences/preprocessor/test_resample.py
@@ -47,24 +47,19 @@ def image_batch():
 class TestResample:
     """Test Resample preprocessor defense."""
 
-    def test_channel_index_error(self):
-        exc_msg = "Data channel must be an integer equal to 1 or 2. The batch dimension is not a valid channel."
-        with pytest.raises(ValueError, match=exc_msg):
-            Resample(sr_original=16000, sr_new=16000, channel_index=3)
-
     def test_sample_rate_original_error(self):
         exc_msg = "Original sampling rate be must a positive integer."
         with pytest.raises(ValueError, match=exc_msg):
-            Resample(sr_original=0, sr_new=16000, channel_index=1)
+            Resample(sr_original=0, sr_new=16000)
 
     def test_sample_rate_new_error(self):
         exc_msg = "New sampling rate be must a positive integer."
         with pytest.raises(ValueError, match=exc_msg):
-            Resample(sr_original=16000, sr_new=0, channel_index=1)
+            Resample(sr_original=16000, sr_new=0)
 
     def test_non_temporal_data_error(self, image_batch):
         test_input = image_batch
-        resample = Resample(16000, 16000, channel_index=2)
+        resample = Resample(16000, 16000)
 
         exc_msg = "Resampling can only be applied to temporal data across at least one channel."
         with pytest.raises(ValueError, match=exc_msg):
@@ -76,7 +71,7 @@ class TestResample:
         mocker.patch("resampy.resample", autospec=True)
         resampy.resample.return_value = test_input[:, :, :sr_new]
 
-        resampler = Resample(sr_original=sr_orig, sr_new=sr_new, channel_index=1)
+        resampler = Resample(sr_original=sr_orig, sr_new=sr_new, channels_first=True)
         assert resampler(test_input).shape == test_output.shape
 
 

--- a/tests/defences/preprocessor/test_spatial_smoothing.py
+++ b/tests/defences/preprocessor/test_spatial_smoothing.py
@@ -68,39 +68,32 @@ class TestLocalSpatialSmoothing:
     def test_spatial_smoothing_median_filter_call(self):
         test_input = np.array([[[[1, 2], [3, 4]]]])
         test_output = np.array([[[[1, 2], [3, 3]]]])
-        spatial_smoothing = SpatialSmoothing(channel_index=1, window_size=2)
+        spatial_smoothing = SpatialSmoothing(channels_first=True, window_size=2)
 
         assert_array_equal(spatial_smoothing(test_input)[0], test_output)
 
     @pytest.mark.parametrize("channels_first", [True, False])
     @pytest.mark.parametrize("window_size", [1, 2, 10])
     def test_spatial_smoothing_image_data(self, image_batch, channels_first, window_size):
-        channel_index = 1 if channels_first else 3
         test_input, test_output = image_batch
-        spatial_smoothing = SpatialSmoothing(channel_index=channel_index, window_size=window_size)
+        spatial_smoothing = SpatialSmoothing(channels_first=channels_first, window_size=window_size)
 
         assert_array_equal(spatial_smoothing(test_input)[0], test_output)
 
     @pytest.mark.parametrize("channels_first", [True, False])
     def test_spatial_smoothing_video_data(self, video_batch, channels_first):
-        channel_index = 1 if channels_first else 4
         test_input, test_output = video_batch
-        spatial_smoothing = SpatialSmoothing(channel_index=channel_index, window_size=2)
+        spatial_smoothing = SpatialSmoothing(channels_first=channels_first, window_size=2)
 
         assert_array_equal(spatial_smoothing(test_input)[0], test_output)
 
     def test_non_spatial_data_error(self, tabular_batch):
         test_input = tabular_batch
-        spatial_smoothing = SpatialSmoothing(channel_index=1)
+        spatial_smoothing = SpatialSmoothing(channels_first=True)
 
-        exc_msg = "Feature vectors detected. Smoothing can only be applied to data with spatial dimensions."
+        exc_msg = "Unrecognized input dimension. Spatial smoothing can only be applied to image and video data."
         with pytest.raises(ValueError, match=exc_msg):
             spatial_smoothing(test_input)
-
-    def test_channel_index_error(self):
-        exc_msg = "Data channel must be an integer equal to 1, 3 or 4. The batch dimension is not a valid channel."
-        with pytest.raises(ValueError, match=exc_msg):
-            SpatialSmoothing(channel_index=0)
 
     def test_window_size_error(self):
         exc_msg = "Sliding window size must be a positive integer."

--- a/tests/defences/test_thermometer_encoding.py
+++ b/tests/defences/test_thermometer_encoding.py
@@ -92,7 +92,7 @@ class TestThermometerEncoding(unittest.TestCase):
         x = np.random.rand(5, 2, 28, 28)
         x_copy = x.copy()
         num_space = 5
-        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channel_index=1)
+        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channels_first=True)
         x_encoded, _ = encoder(x)
         self.assertTrue((x == x_copy).all())
         self.assertEqual(x_encoded.shape, (5, 10, 28, 28))
@@ -109,7 +109,7 @@ class TestThermometerEncoding(unittest.TestCase):
         x = np.random.rand(10, 4)
         x_original = x.copy()
         num_space = 5
-        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channel_index=1)
+        encoder = ThermometerEncoding(clip_values=(0, 1), num_space=num_space, channels_first=True)
         x_encoded, _ = encoder(x)
         self.assertEqual(x_encoded.shape, (10, 20))
         # Check that x has not been modified by attack and classifier

--- a/tests/estimators/classification/test_classifier.py
+++ b/tests/estimators/classification/test_classifier.py
@@ -22,9 +22,9 @@ import unittest
 
 import numpy as np
 
+from art.estimators.classification.classifier import ClassGradientsMixin, ClassifierMixin
 from art.estimators.estimator import BaseEstimator, LossGradientsMixin, NeuralNetworkMixin
-from art.estimators.classification.classifier import ClassifierMixin, ClassGradientsMixin
-
+from art.utils import Deprecated
 from tests.utils import TestBase, master_seed
 
 logger = logging.getLogger(__name__)
@@ -50,8 +50,8 @@ class ClassifierInstance(ClassifierMixin, BaseEstimator):
 class ClassifierNeuralNetworkInstance(
     ClassGradientsMixin, ClassifierMixin, NeuralNetworkMixin, LossGradientsMixin, BaseEstimator
 ):
-    def __init__(self, clip_values, channel_index=1):
-        super(ClassifierNeuralNetworkInstance, self).__init__(clip_values=clip_values, channel_index=channel_index)
+    def __init__(self, clip_values, channels_first=True):
+        super(ClassifierNeuralNetworkInstance, self).__init__(clip_values=clip_values, channels_first=channels_first)
 
     def class_gradient(self, x, label=None, **kwargs):
         pass
@@ -130,7 +130,7 @@ class TestClassifierNeuralNetwork(TestBase):
         classifier = ClassifierNeuralNetworkInstance((0, 1))
         repr_ = repr(classifier)
         self.assertIn("ClassifierNeuralNetworkInstance", repr_)
-        self.assertIn("channel_index=1", repr_)
+        self.assertIn(f"channel_index={Deprecated}, channels_first=True", repr_)
         self.assertIn("clip_values=[0. 1.]", repr_)
         self.assertIn("defences=None", repr_)
         self.assertIn("preprocessing=None", repr_)

--- a/tests/estimators/classification/test_ensemble.py
+++ b/tests/estimators/classification/test_ensemble.py
@@ -20,13 +20,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import unittest
 
-import numpy as np
 import keras.backend as k
+import numpy as np
 
 from art.estimators.classification.ensemble import EnsembleClassifier
-
+from art.utils import Deprecated
 from tests.utils import TestBase, get_image_classifier_kr
-
 
 logger = logging.getLogger(__name__)
 
@@ -255,8 +254,8 @@ class TestEnsembleClassifier(TestBase):
         self.assertIn("art.estimators.classification.ensemble.EnsembleClassifier", repr_)
         self.assertIn("classifier_weights=array([0.5, 0.5])", repr_)
         self.assertIn(
-            "channel_index=3, clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, "
-            "postprocessing_defences=None, preprocessing=(0, 1)",
+            f"channel_index={Deprecated}, channels_first=False, clip_values=array([0., 1.], dtype=float32), "
+            "preprocessing_defences=None, postprocessing_defences=None, preprocessing=(0, 1)",
             repr_,
         )
 

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -17,28 +17,28 @@
 # SOFTWARE.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import logging
-import unittest
+import os
 import pickle
+import unittest
 
+import numpy as np
 import tensorflow as tf
+from tensorflow.keras.callbacks import LearningRateScheduler
+from tensorflow.keras.layers import Conv2D, Dense, Dropout, Flatten, Input, MaxPooling2D
+from tensorflow.keras.models import Model
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+
+from art.config import ART_DATA_PATH
+from art.data_generators import KerasDataGenerator
+from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
+from art.estimators.classification.keras import KerasClassifier, generator_fit
+from art.utils import Deprecated
+from tests.utils import TestBase, get_image_classifier_kr_tf, master_seed
 
 if tf.__version__[0] == "2":
     tf.compat.v1.disable_eager_execution()
-from tensorflow.keras.layers import Dense, Conv2D, MaxPooling2D, Dropout, Input, Flatten
-from tensorflow.keras.models import Model
-from tensorflow.keras.preprocessing.image import ImageDataGenerator
-from tensorflow.keras.callbacks import LearningRateScheduler
 
-import numpy as np
-
-from art.config import ART_DATA_PATH
-from art.estimators.classification.keras import KerasClassifier, generator_fit
-from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
-from art.data_generators import KerasDataGenerator
-
-from tests.utils import TestBase, master_seed, get_image_classifier_kr_tf
 
 logger = logging.getLogger(__name__)
 
@@ -562,7 +562,7 @@ class TestKerasClassifierTensorFlow(TestBase):
             loaded = pickle.load(load_file)
 
         np.testing.assert_equal(keras_model._clip_values, loaded._clip_values)
-        self.assertEqual(keras_model._channel_index, loaded._channel_index)
+        self.assertEqual(keras_model._channels_first, loaded._channels_first)
         self.assertEqual(keras_model._use_logits, loaded._use_logits)
         self.assertEqual(keras_model._input_layer, loaded._input_layer)
         self.assertEqual(self.functional_model.get_config(), loaded._model.get_config())
@@ -574,7 +574,7 @@ class TestKerasClassifierTensorFlow(TestBase):
         classifier = get_image_classifier_kr_tf()
         repr_ = repr(classifier)
         self.assertIn("art.estimators.classification.keras.KerasClassifier", repr_)
-        self.assertIn("use_logits=False, channel_index=3", repr_)
+        self.assertIn(f"use_logits=False, channel_index={Deprecated}, channels_first=False", repr_)
         self.assertIn(
             "clip_values=array([0., 1.], dtype=float32), preprocessing_defences=None, postprocessing_defences=None, "
             "preprocessing=(0, 1)",

--- a/tests/estimators/classification/test_mxnet.py
+++ b/tests/estimators/classification/test_mxnet.py
@@ -17,17 +17,17 @@
 # SOFTWARE.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import logging
-import unittest
+import os
 import tempfile
+import unittest
 
 import numpy as np
-from mxnet import init, gluon
+from mxnet import gluon, init
 from mxnet.gluon import nn
 
 from art.estimators.classification.mxnet import MXClassifier
-
+from art.utils import Deprecated
 from tests.utils import TestBase, master_seed
 
 logger = logging.getLogger(__name__)
@@ -208,7 +208,9 @@ class TestMXClassifier(TestBase):
         repr_ = repr(self.classifier)
         self.assertIn("art.estimators.classification.mxnet.MXClassifier", repr_)
         self.assertIn("input_shape=(1, 28, 28), nb_classes=10", repr_)
-        self.assertIn("channel_index=1, clip_values=array([0., 1.], dtype=float32)", repr_)
+        self.assertIn(
+            f"channel_index={Deprecated}, channels_first=True, clip_values=array([0., 1.], dtype=float32)", repr_
+        )
         self.assertIn("defences=None, preprocessing=(0, 1)", repr_)
 
 

--- a/tests/estimators/classification/test_pytorch.py
+++ b/tests/estimators/classification/test_pytorch.py
@@ -17,11 +17,11 @@
 # SOFTWARE.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import logging
-import unittest
-import tempfile
+import os
 import pickle
+import tempfile
+import unittest
 
 import numpy as np
 import torch
@@ -33,9 +33,8 @@ from torch.utils.data import DataLoader
 from art.config import ART_DATA_PATH
 from art.data_generators import PyTorchDataGenerator
 from art.estimators.classification.pytorch import PyTorchClassifier
-
+from art.utils import Deprecated
 from tests.utils import TestBase, get_image_classifier_pt, master_seed
-
 
 logger = logging.getLogger(__name__)
 
@@ -576,7 +575,7 @@ class TestPyTorchClassifier(TestBase):
     def test_repr(self):
         repr_ = repr(self.module_classifier)
         self.assertIn("art.estimators.classification.pytorch.PyTorchClassifier", repr_)
-        self.assertIn("input_shape=(1, 28, 28), nb_classes=10, channel_index=1", repr_)
+        self.assertIn(f"input_shape=(1, 28, 28), nb_classes=10, channel_index={Deprecated}, channels_first=True", repr_)
         self.assertIn("clip_values=array([0., 1.], dtype=float32)", repr_)
         self.assertIn("defences=None, preprocessing=(0, 1)", repr_)
 
@@ -592,7 +591,7 @@ class TestPyTorchClassifier(TestBase):
         with open(full_path, "rb") as f:
             loaded = pickle.load(f)
             np.testing.assert_equal(self.module_classifier._clip_values, loaded._clip_values)
-            self.assertEqual(self.module_classifier._channel_index, loaded._channel_index)
+            self.assertEqual(self.module_classifier._channels_first, loaded._channels_first)
             self.assertEqual(set(self.module_classifier.__dict__.keys()), set(loaded.__dict__.keys()))
 
         # Test predict

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,11 +20,11 @@ Module providing convenience functions specifically for unit tests.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
-import logging
 import json
-import time
+import logging
+import os
 import pickle
+import time
 import unittest
 
 import numpy as np
@@ -93,13 +93,13 @@ class TestBase(unittest.TestCase):
 
         # Check that the test data has not been modified, only catches changes in attack.generate if self has been used
         np.testing.assert_array_almost_equal(
-            self._x_train_mnist_original[0: self.n_train], self.x_train_mnist, decimal=3
+            self._x_train_mnist_original[0 : self.n_train], self.x_train_mnist, decimal=3
         )
         np.testing.assert_array_almost_equal(
-            self._y_train_mnist_original[0: self.n_train], self.y_train_mnist, decimal=3
+            self._y_train_mnist_original[0 : self.n_train], self.y_train_mnist, decimal=3
         )
-        np.testing.assert_array_almost_equal(self._x_test_mnist_original[0: self.n_test], self.x_test_mnist, decimal=3)
-        np.testing.assert_array_almost_equal(self._y_test_mnist_original[0: self.n_test], self.y_test_mnist, decimal=3)
+        np.testing.assert_array_almost_equal(self._x_test_mnist_original[0 : self.n_test], self.x_test_mnist, decimal=3)
+        np.testing.assert_array_almost_equal(self._y_test_mnist_original[0 : self.n_test], self.y_test_mnist, decimal=3)
 
         np.testing.assert_array_almost_equal(self._x_train_iris_original, self.x_train_iris, decimal=3)
         np.testing.assert_array_almost_equal(self._y_train_iris_original, self.y_train_iris, decimal=3)
@@ -340,30 +340,36 @@ def get_image_classifier_tf_v2(from_logits=False):
         optimizer.apply_gradients(zip(gradients, model.trainable_variables))
 
     model = Sequential()
-    model.add(Conv2D(
-        filters=1,
-        kernel_size=7,
-        activation="relu",
-        kernel_initializer=_tf_weights_loader("MNIST", "W", "CONV2D", 2),
-        bias_initializer=_tf_weights_loader("MNIST", "B", "CONV2D", 2),
-        input_shape=(28, 28, 1),
-    ))
+    model.add(
+        Conv2D(
+            filters=1,
+            kernel_size=7,
+            activation="relu",
+            kernel_initializer=_tf_weights_loader("MNIST", "W", "CONV2D", 2),
+            bias_initializer=_tf_weights_loader("MNIST", "B", "CONV2D", 2),
+            input_shape=(28, 28, 1),
+        )
+    )
     model.add(MaxPool2D(pool_size=(4, 4), strides=(4, 4), padding="valid", data_format=None))
     model.add(Flatten())
     if from_logits:
-        model.add(Dense(
-            10,
-            activation="linear",
-            kernel_initializer=_tf_weights_loader("MNIST", "W", "DENSE", 2),
-            bias_initializer=_tf_weights_loader("MNIST", "B", "DENSE", 2),
-        ))
+        model.add(
+            Dense(
+                10,
+                activation="linear",
+                kernel_initializer=_tf_weights_loader("MNIST", "W", "DENSE", 2),
+                bias_initializer=_tf_weights_loader("MNIST", "B", "DENSE", 2),
+            )
+        )
     else:
-        model.add(Dense(
-            10,
-            activation="softmax",
-            kernel_initializer=_tf_weights_loader("MNIST", "W", "DENSE", 2),
-            bias_initializer=_tf_weights_loader("MNIST", "B", "DENSE", 2),
-        ))
+        model.add(
+            Dense(
+                10,
+                activation="softmax",
+                kernel_initializer=_tf_weights_loader("MNIST", "W", "DENSE", 2),
+                bias_initializer=_tf_weights_loader("MNIST", "B", "DENSE", 2),
+            )
+        )
 
     loss_object = tf.keras.losses.SparseCategoricalCrossentropy()
 
@@ -878,7 +884,7 @@ def get_classifier_mx():
         nb_classes=10,
         optimizer=trainer,
         ctx=None,
-        channel_index=1,
+        channels_first=True,
         clip_values=(0, 1),
         defences=None,
         preprocessing=(0, 1),
@@ -982,7 +988,7 @@ def get_tabular_classifier_tf_v1(load_init=True, sess=None):
         loss=loss,
         learning=None,
         sess=sess,
-        channel_index=1,
+        channels_first=True,
     )
 
     return tfc, sess
@@ -1170,7 +1176,7 @@ def get_tabular_classifier_kr(load_init=True):
     model.compile(loss="categorical_crossentropy", optimizer=keras.optimizers.Adam(lr=0.001), metrics=["accuracy"])
 
     # Get classifier
-    krc = KerasClassifier(model, clip_values=(0, 1), use_logits=False, channel_index=1)
+    krc = KerasClassifier(model, clip_values=(0, 1), use_logits=False, channels_first=True)
 
     return krc
 
@@ -1253,7 +1259,7 @@ def get_tabular_classifier_pt(load_init=True):
         input_shape=(4,),
         nb_classes=3,
         clip_values=(0, 1),
-        channel_index=1,
+        channels_first=True,
     )
 
     return ptc

--- a/tests/wrappers/test_expectation.py
+++ b/tests/wrappers/test_expectation.py
@@ -127,7 +127,7 @@ class TestExpectationVectors(unittest.TestCase):
                 yield t
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         classifier = ExpectationOverTransformations(classifier, sample_size=1, transformation=transformation)
         attack = FastGradientMethod(classifier, eps=1)
         x_test_adv = attack.generate(x_test)

--- a/tests/wrappers/test_query_efficient_bb.py
+++ b/tests/wrappers/test_query_efficient_bb.py
@@ -153,7 +153,7 @@ class TestQueryEfficientVectors(unittest.TestCase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        classifier = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        classifier = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         classifier = QueryEfficientBBGradientEstimation(classifier, 20, 1 / 64.0, round_samples=1 / 255.0)
         attack = FastGradientMethod(classifier, eps=1)
         x_test_adv = attack.generate(x_test)

--- a/tests/wrappers/test_randomized_smoothing.py
+++ b/tests/wrappers/test_randomized_smoothing.py
@@ -165,7 +165,7 @@ class TestRandomizedSmoothingVectors(unittest.TestCase):
         classifier = get_tabular_classifier_kr()
 
         # Recreate a classifier without clip values
-        krc = KerasClassifier(model=classifier._model, use_logits=False, channel_index=1)
+        krc = KerasClassifier(model=classifier._model, use_logits=False, channels_first=True)
         rs = RandomizedSmoothing(classifier=krc, sample_size=100, scale=0.01, alpha=0.001)
         attack = FastGradientMethod(rs, eps=1)
         x_test_adv = attack.generate(x_test)


### PR DESCRIPTION
# Description

This PR deprecates the use of `channel_index` in favor of `channel_first`, which will be removed in future release `1.5.0`. More background information about the reason can be found in #423. 

In the `art` directory all classes and methods have been changed such that usage of `channel_index` continues to work. This is done by inferring the correct `channels_first` boolean based on the given `channel_index` value. The specific checks have been marked with a comment.

Furthermore, code in directories other than `art` has been changed such that `channel_index` is removed completely and replaced with `channels_first` functionality. Those directories are `tests`, `notebooks` and `examples`.

Closes #423. 

## Type of change

- [x] New feature (non-breaking)
- [x] This change requires a documentation update

# Testing

All affected tests were executed locally.

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
