### PR TITLE
Only raise a DeprecationWarning if deprecated keyword argument is used

### DIFF
--- a/art/utils.py
+++ b/art/utils.py
@@ -123,6 +123,11 @@ def deprecated_keyword_arg(identifier, end_version, *, reason="", replaced_by=""
             params = signature(function).bind(*args, **kwargs)
             params.apply_defaults()
 
+            if params.signature.parameters[identifier].default is not Deprecated:
+                raise ValueError("Deprecated keyword argument must default to the Decorator singleton.")
+            if replaced_by != "" and replaced_by not in params.arguments:
+                raise ValueError("Deprecated keyword replacement not found in function signature.")
+
             if params.arguments[identifier] is not Deprecated:
                 warnings.simplefilter("always", category=DeprecationWarning)
                 warnings.warn(deprecated_msg + replaced_msg + reason_msg, category=DeprecationWarning, stacklevel=2)

--- a/art/utils.py
+++ b/art/utils.py
@@ -95,14 +95,9 @@ def deprecated_keyword_arg(identifier, end_version, *, reason="", replaced_by=""
     """
     Deprecate a keyword argument and raise a `DeprecationWarning`.
 
-    The `@deprecated_keyword_arg` decorator is used to deprecate keyword arguments. Several cases are supported. For
-    example one can use it to depcreate the default value of a keyword or rename a keyword identifier. The following
-    code examples provide different use cases of how to use the decorator.
 
     .. code-block:: python
 
-    @deprecated_keyword_arg("verbose", "1.1.0", replaced_by="verbose=False")
-    def simple_addition(a, b, verbose=True):
         return a + b
 
     :param identifier: Keyword identifier.
@@ -125,9 +120,13 @@ def deprecated_keyword_arg(identifier, end_version, *, reason="", replaced_by=""
 
         @wraps(function)
         def wrapper(*args, **kwargs):
-            warnings.simplefilter("always", category=DeprecationWarning)
-            warnings.warn(deprecated_msg + replaced_msg + reason_msg, category=DeprecationWarning, stacklevel=2)
-            warnings.simplefilter("default", category=DeprecationWarning)
+            params = signature(function).bind(*args, **kwargs)
+            params.apply_defaults()
+
+            if params.arguments[identifier] is not Deprecated:
+                warnings.simplefilter("always", category=DeprecationWarning)
+                warnings.warn(deprecated_msg + replaced_msg + reason_msg, category=DeprecationWarning, stacklevel=2)
+                warnings.simplefilter("default", category=DeprecationWarning)
             return function(*args, **kwargs)
 
         return wrapper

--- a/art/utils.py
+++ b/art/utils.py
@@ -25,6 +25,7 @@ import math
 import os
 import warnings
 from functools import wraps
+from inspect import signature
 
 import numpy as np
 
@@ -34,12 +35,27 @@ logger = logging.getLogger(__name__)
 # ------------------------------------------------------------------------------------------------- DEPRECATION
 
 
+class _Deprecated:
+    """
+    Create Deprecated() singleton object.
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if _Deprecated._instance is None:
+            _Deprecated._instance = object.__new__(cls)
+        return _Deprecated._instance
+
+
+Deprecated = _Deprecated()
+
+
 def deprecated(end_version, *, reason="", replaced_by=""):
     """
     Deprecate a function or method and raise a `DeprecationWarning`.
 
     The `@deprecated` decorator is used to deprecate functions and methods. Several cases are supported. For example
-    one can use it to depcreate a function that has become redundant or renaming a function. The following code examples
     provide different use cases of how to use decorator.
 
     .. code-block:: python

--- a/art/utils.py
+++ b/art/utils.py
@@ -56,6 +56,7 @@ def deprecated(end_version, *, reason="", replaced_by=""):
     Deprecate a function or method and raise a `DeprecationWarning`.
 
     The `@deprecated` decorator is used to deprecate functions and methods. Several cases are supported. For example
+    one can use it to deprecate a function that has become redundant or rename a function. The following code examples
     provide different use cases of how to use decorator.
 
     .. code-block:: python
@@ -95,9 +96,20 @@ def deprecated_keyword_arg(identifier, end_version, *, reason="", replaced_by=""
     """
     Deprecate a keyword argument and raise a `DeprecationWarning`.
 
+    The `@deprecated_keyword_arg` decorator is used to deprecate keyword arguments. The deprecated keyword argument must
+    default to `Deprecated`. Several use cases are supported. For example one can use it to to rename a keyword
+    identifier. The following code examples provide different use cases of how to use the decorator.
 
     .. code-block:: python
 
+    @deprecated_keyword_arg("print", "1.1.0", replaced_by="verbose")
+    def simple_addition(a, b, print=Deprecated, verbose=False):
+        if verbose:
+            print(a + b)
+        return a + b
+
+    @deprecated_keyword_arg("verbose", "1.1.0")
+    def simple_addition(a, b, verbose=Deprecated):
         return a + b
 
     :param identifier: Keyword identifier.

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -121,6 +121,26 @@ class TestDeprecatedKeyword:
         warn_obj = recwarn.pop(DeprecationWarning)
         assert str(warn_obj.message) == warn_msg_expected
 
+    def test_replaced_by_keyword_missing_signature_error(self, recwarn):
+        @deprecated_keyword_arg("b", "1.3.0", replaced_by="c")
+        def simple_addition(a=1, b=Deprecated):
+            result = a if b is Deprecated else a + b
+            return result
+
+        exc_msg = "Deprecated keyword replacement not found in function signature."
+        with pytest.raises(ValueError, match=exc_msg):
+            simple_addition(a=1)
+
+    def test_deprecated_keyword_default_value_error(self):
+        @deprecated_keyword_arg("a", "1.3.0")
+        def simple_addition(a=None, b=1):
+            result = a if a is None else a + b
+            return result
+
+        exc_msg = "Deprecated keyword argument must default to the Decorator singleton."
+        with pytest.raises(ValueError, match=exc_msg):
+            simple_addition(a=1)
+
 
 if __name__ == "__main__":
     pytest.cmdline.main("-q -s {} --mlFramework=tensorflow --durations=0".format(__file__).split(" "))

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -21,8 +21,7 @@ import logging
 
 import pytest
 
-from art.utils import deprecated
-from art.utils import deprecated_keyword_arg
+from art.utils import deprecated, deprecated_keyword_arg
 
 logger = logging.getLogger(__name__)
 
@@ -74,13 +73,22 @@ class TestDeprecatedKeyword:
     Test the deprecation decorator for keyword arguments.
     """
 
-    def test_deprecated_simple(self):
+    def test_deprecated_keyword_used(self):
         @deprecated_keyword_arg("a", "1.3.0")
         def simple_addition(a=1, b=1):
             return a + b
 
         with pytest.deprecated_call():
             simple_addition()
+
+    def test_deprecated_keyword_not_used(self, recwarn):
+        @deprecated_keyword_arg("c", "1.3.0")
+        def simple_addition(a, b, c=None):
+            result = a + b if c is None else a + b + c
+            return result
+
+        simple_addition(1, 2, c=1)
+        assert len(recwarn) == 0
 
     def test_deprecated_reason_keyword(self, recwarn):
         @deprecated_keyword_arg("a", "1.3.0", reason="With some reason message.")


### PR DESCRIPTION
# Description

In the current implementation of the `deprecated_keyword_arg`, we raise a `DeprecationWarning` with every function call. However, we should only raise a warning if a deprecated keyword argument is used. 

In order to facilitate this change, a `Decorator` singleton is introduced. Furthermore, some additional checks on the correct use of the decorator has been added.

Related to #423 

## Type of change

- [x] Fx (non-breaking)
- [x] This change requires a documentation update

# Testing

Additional tests to cover correct use have been added.

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
