### PR TITLE
Remove tanh_smoother from art.uitls.tanh_to_original

### DIFF
--- a/art/attacks/evasion/carlini.py
+++ b/art/attacks/evasion/carlini.py
@@ -346,9 +346,7 @@ class CarliniL2Method(EvasionAttack):
 
                         x_adv1 = x_adv_batch_tanh[active_and_do_halving]
                         new_x_adv_batch_tanh = x_adv1 + lr_mult * perturbation_tanh[do_halving]
-                        new_x_adv_batch = tanh_to_original(
-                            new_x_adv_batch_tanh, clip_min, clip_max, self._tanh_smoother
-                        )
+                        new_x_adv_batch = tanh_to_original(new_x_adv_batch_tanh, clip_min, clip_max)
                         _, l2dist[active_and_do_halving], loss[active_and_do_halving] = self._loss(
                             x_batch[active_and_do_halving],
                             new_x_adv_batch,
@@ -384,9 +382,7 @@ class CarliniL2Method(EvasionAttack):
 
                         x_adv2 = x_adv_batch_tanh[active_and_do_doubling]
                         new_x_adv_batch_tanh = x_adv2 + lr_mult * perturbation_tanh[do_doubling]
-                        new_x_adv_batch = tanh_to_original(
-                            new_x_adv_batch_tanh, clip_min, clip_max, self._tanh_smoother
-                        )
+                        new_x_adv_batch = tanh_to_original(new_x_adv_batch_tanh, clip_min, clip_max)
                         _, l2dist[active_and_do_doubling], loss[active_and_do_doubling] = self._loss(
                             x_batch[active_and_do_doubling],
                             new_x_adv_batch,
@@ -416,9 +412,7 @@ class CarliniL2Method(EvasionAttack):
                         x_adv_batch_tanh[active_and_update_adv] = x_adv4 + best_lr1
 
                         x_adv6 = x_adv_batch_tanh[active_and_update_adv]
-                        x_adv_batch[active_and_update_adv] = tanh_to_original(
-                            x_adv6, clip_min, clip_max, self._tanh_smoother
-                        )
+                        x_adv_batch[active_and_update_adv] = tanh_to_original(x_adv6, clip_min, clip_max)
                         (
                             z_logits[active_and_update_adv],
                             l2dist[active_and_update_adv],

--- a/art/utils.py
+++ b/art/utils.py
@@ -261,7 +261,7 @@ def tanh_to_original(x_tanh, clip_min, clip_max):
     :return: An array holding the transformed input.
     :rtype: `np.ndarray`
     """
-    return np.tanh(x_tanh) * (clip_max - clip_min) + clip_min
+    return (np.tanh(x_tanh) + 1.0) / 2.0 * (clip_max - clip_min) + clip_min
 
 
 # --------------------------------------------------------------------------------------------------- LABELS OPERATIONS

--- a/art/utils.py
+++ b/art/utils.py
@@ -248,7 +248,7 @@ def original_to_tanh(x_original, clip_min, clip_max, tanh_smoother=0.999999):
     return x_tanh
 
 
-def tanh_to_original(x_tanh, clip_min, clip_max, tanh_smoother=0.999999):
+def tanh_to_original(x_tanh, clip_min, clip_max):
     """
     Transform input from tanh to original space.
 
@@ -258,13 +258,10 @@ def tanh_to_original(x_tanh, clip_min, clip_max, tanh_smoother=0.999999):
     :type clip_min: `float` or `np.ndarray`
     :param clip_max: Maximum clipping value.
     :type clip_max: `float` or `np.ndarray`
-    :param tanh_smoother: Scalar for dividing arguments of tanh to avoid division by zero.
-    :type tanh_smoother: `float`
     :return: An array holding the transformed input.
     :rtype: `np.ndarray`
     """
-    x_original = (np.tanh(x_tanh) / tanh_smoother + 1) / 2
-    return x_original * (clip_max - clip_min) + clip_min
+    return np.tanh(x_tanh) * (clip_max - clip_min) + clip_min
 
 
 # --------------------------------------------------------------------------------------------------- LABELS OPERATIONS


### PR DESCRIPTION
# Description

This pull request removes the argument `tanh_smoother` from `art.uitls.tanh_to_original` used in `CarliniL2Method` and `CarliniLInfMethod` because in rare cases it can lead to values outside of the clip values.

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
