### PR TITLE
Add H.264/MPEG-4 AVC video compression defense

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN pip3 install keras==2.3.1
 
 RUN pip3 install matplotlib==3.2.1 numpy==1.18.1 scipy==1.4.1 six==1.13.0 Pillow==7.0.0 scikit-learn==0.22.1 lightgbm==2.3.1
 RUN pip3 install pytest-pep8==1.0.6 codecov==2.0.22 h5py==2.10.0 requests==2.23.0 statsmodels==0.11.0  cma==2.7.0 pydub==0.23.1
-RUN pip3 install tqdm==4.45.0
+RUN pip3 install tqdm==4.45.0 ffmpeg-python==0.2.0
 #TODO check if jupyter notebook works
 RUN pip3 install jupyter==1.0.0 && pip3 install jupyterlab==2.1.0
 # https://stackoverflow.com/questions/49024624/how-to-dockerize-jupyter-lab

--- a/README-cn.md
+++ b/README-cn.md
@@ -74,6 +74,7 @@ ART正在不断发展中。 我们欢迎您的反馈，错误报告和对ART建�
 * Backdoor Attack ([Gu, et. al., 2017](https://arxiv.org/abs/1708.06733))
 
 **防御 - 预处理器：**
+* 视频压缩
 * 重采样 ([Yang et al., 2019](https://arxiv.org/abs/1809.10875))
 * 温度计编码 ([Buckman et al., 2018](https://openreview.net/forum?id=S18Su--CW))
 * MP3压缩 ([Carlini, N. & Wagner, D., 2018](https://arxiv.org/abs/1801.01944))

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Get in touch with us on [Slack](https://ibm-art.slack.com) (invite [here](https:
 * Feature Collision Attack ([Shafahi, Huang et. al., 2018](https://arxiv.org/pdf/1804.00792.pdf))
 
 **Defences - Preprocessor:**
+* Video compression
 * Resampling ([Yang et al., 2019](https://arxiv.org/abs/1809.10875))
 * Thermometer encoding ([Buckman et al., 2018](https://openreview.net/forum?id=S18Su--CW))
 * MP3 compression ([Carlini, N. & Wagner, D., 2018](https://arxiv.org/abs/1801.01944))

--- a/art/config.py
+++ b/art/config.py
@@ -70,5 +70,11 @@ if not os.path.exists(_config_path):
     except IOError:
         logger.warning("Unable to create configuration file", exc_info=True)
 
+if not os.path.exists(_config["ART_DATA_PATH"]):
+    try:
+        os.makedirs(_config["ART_DATA_PATH"])
+    except OSError:
+        logger.warning("Unable to create folder for ART_DATA_PATH dir.", exc_info=True)
+
 if "ART_DATA_PATH" in _config:
     ART_DATA_PATH = _config["ART_DATA_PATH"]

--- a/art/defences/preprocessor/__init__.py
+++ b/art/defences/preprocessor/__init__.py
@@ -12,3 +12,4 @@ from art.defences.preprocessor.resample import Resample
 from art.defences.preprocessor.spatial_smoothing import SpatialSmoothing
 from art.defences.preprocessor.thermometer_encoding import ThermometerEncoding
 from art.defences.preprocessor.variance_minimization import TotalVarMin
+from art.defences.preprocessor.video_compression import VideoCompression

--- a/art/defences/preprocessor/video_compression.py
+++ b/art/defences/preprocessor/video_compression.py
@@ -1,0 +1,160 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module implements a wrapper for video compression defence with FFmpeg.
+
+| Please keep in mind the limitations of defences. For details on how to evaluate classifier security in general,
+    see https://arxiv.org/abs/1902.06705.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import os
+from tempfile import TemporaryDirectory
+
+import numpy as np
+
+from art.config import ART_DATA_PATH
+from art.defences.preprocessor.preprocessor import Preprocessor
+
+logger = logging.getLogger(__name__)
+
+
+class VideoCompression(Preprocessor):
+    """
+    Implement FFmpeg wrapper for video compression defence based on H.264/MPEG-4 AVC.
+
+    Video compression uses H.264 video encoding. The video quality is controlled with the constant rate factor
+    parameter. More information on the constant rate factor: https://trac.ffmpeg.org/wiki/Encode/H.264.
+    """
+
+    params = ["video_format", "constant_rate_factor", "channels_first"]
+
+    def __init__(
+        self, *, video_format, constant_rate_factor=28, channels_first=False, apply_fit=False, apply_predict=True,
+    ):
+        """
+        Create an instance of VideoCompression.
+
+
+        :param video_format: Specify one of supported video file extensions, e.g. `avi`, `mp4` or `mkv`.
+        :type video_format: `str`
+        :param constant_rate_factor: Specifiy constant rate factor (range 0 to 51, where 0 is lossless)
+        :type constant_rate_factor: `int`
+        :param channels_first: Set channels first or last.
+        :type channels_first: `bool`
+        :param apply_fit: True if applied during fitting/training.
+        :type apply_fit: `bool`
+        :param apply_predict: True if applied during predicting.
+        :type apply_predict: `bool`
+        """
+        super().__init__()
+        self._is_fitted = True
+        self._apply_fit = apply_fit
+        self._apply_predict = apply_predict
+        self.set_params(
+            video_format=video_format, constant_rate_factor=constant_rate_factor, channels_first=channels_first,
+        )
+
+    @property
+    def apply_fit(self):
+        return self._apply_fit
+
+    @property
+    def apply_predict(self):
+        return self._apply_predict
+
+    def __call__(self, x, y=None):
+        """
+        Apply video compression to sample `x`.
+
+        :param x: Sample to compress of shape NCFHW or NFHWC. `x` values are expected to be in the data range [0, 255].
+        :type x: `np.ndarray`
+        :param y: Labels of the sample `x`. This function does not affect them in any way.
+        :type y: `np.ndarray`
+        :return: Compressed sample.
+        :rtype: `np.ndarray`
+        """
+
+        def compress_video(x, video_format, constant_rate_factor, dir_=""):
+            """
+            Apply video compression to video input of shape (frames, height, width, channel).
+            """
+            import ffmpeg
+
+            video_path = os.path.join(dir_, f"tmp_video.{video_format}")
+            _, height, width, _ = x.shape
+
+            # numpy to local video file
+            process = (
+                ffmpeg.input("pipe:", format="rawvideo", pix_fmt="rgb24", s=f"{width}x{height}")
+                .output(video_path, pix_fmt="yuv420p", vcodec="libx264", crf=constant_rate_factor)
+                .overwrite_output()
+                .run_async(pipe_stdin=True, quiet=True)
+            )
+            process.stdin.write(x.flatten().astype(np.uint8).tobytes())
+            process.stdin.close()
+            process.wait()
+
+            # local video file to numpy
+            stdout, _ = (
+                ffmpeg.input(video_path)
+                .output("pipe:", format="rawvideo", pix_fmt="rgb24")
+                .run(capture_stdout=True, quiet=True)
+            )
+            return np.frombuffer(stdout, np.uint8).reshape(x.shape)
+
+        if x.ndim != 5:
+            raise ValueError("Video compression can only be applied to spatio-temporal data.")
+
+        if self.channels_first:
+            x = np.transpose(x, (0, 2, 3, 4, 1))
+
+        # apply video compression per video item
+        x_compressed = x.copy()
+        with TemporaryDirectory(dir=ART_DATA_PATH) as tmp_dir:
+            for i, x_i in enumerate(x):
+                x_compressed[i] = compress_video(x_i, self.video_format, self.constant_rate_factor, dir_=tmp_dir)
+
+        if self.channels_first:
+            x_compressed = np.transpose(x_compressed, (0, 4, 1, 2, 3))
+
+        return x_compressed, y
+
+    def estimate_gradient(self, x, grad):
+        return grad
+
+    def fit(self, x, y=None, **kwargs):
+        """
+        No parameters to learn for this method; do nothing.
+        """
+        pass
+
+    def set_params(self, **kwargs):
+        """
+        Take in a dictionary of parameters and applies defence-specific checks before saving them as attributes.
+        """
+        super().set_params(**kwargs)
+
+        if not (
+            isinstance(self.constant_rate_factor, (int, np.int))
+            and self.constant_rate_factor >= 0
+            and self.constant_rate_factor < 52
+        ):
+            raise ValueError("Constant rate factor must be an integer in the range [0, 51].")
+        return True

--- a/art/defences/preprocessor/video_compression.py
+++ b/art/defences/preprocessor/video_compression.py
@@ -51,7 +51,6 @@ class VideoCompression(Preprocessor):
         """
         Create an instance of VideoCompression.
 
-
         :param video_format: Specify one of supported video file extensions, e.g. `avi`, `mp4` or `mkv`.
         :type video_format: `str`
         :param constant_rate_factor: Specifiy constant rate factor (range 0 to 51, where 0 is lossless)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ tests_require = [
     "GPy==1.9.9",
     "pytest-mock==3.1.0",
     "resampy==0.2.2",
+    "ffmpeg-python==0.2.0",
 ]
 
 docs_require = ["sphinx >= 1.4", "sphinx_rtd_theme"]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -27,6 +27,7 @@ catboost==0.22
 GPy==1.9.9
 pytest-mock==3.1.0
 resampy==0.2.2
+ffmpeg-python==0.2.0
 
 tqdm==4.45.0
 

--- a/tests/defences/preprocessor/test_video_compression.py
+++ b/tests/defences/preprocessor/test_video_compression.py
@@ -1,0 +1,81 @@
+# MIT License
+#
+# Copyright (C) The Adversarial Robustness Toolbox (ART) Authors 2020
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from art.defences.preprocessor import VideoCompression
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def video_batch(channels_first):
+    """
+    Video fixture of shape NFHWC and NCFHW.
+    """
+    test_input = np.stack((np.zeros((3, 25, 4, 6)), np.ones((3, 25, 4, 6))))
+    if not channels_first:
+        test_input = np.transpose(test_input, (0, 2, 3, 4, 1))
+    test_output = test_input.copy()
+    return test_input, test_output
+
+
+@pytest.fixture
+def image_batch():
+    """Create image fixture of shape (batch_size, channels, width, height)."""
+    return np.zeros((2, 1, 4, 4))
+
+
+class TestVideoCompression:
+    """Test VideoCompresssion."""
+
+    @pytest.mark.parametrize("channels_first", [True, False])
+    def test_video_compresssion(self, video_batch, channels_first):
+        test_input, test_output = video_batch
+        video_compression = VideoCompression(video_format="mp4", constant_rate_factor=0, channels_first=channels_first)
+
+        assert_array_equal(video_compression(test_input)[0], test_output)
+
+    def test_compress_video_call(self):
+        test_input = np.arange(12).reshape(1, 3, 1, 2, 2)
+        video_compression = VideoCompression(video_format="mp4", constant_rate_factor=50, channels_first=True)
+
+        assert np.any(np.not_equal(video_compression(test_input)[0], test_input))
+
+    @pytest.mark.parametrize("constant_rate_factor", [-1, 52])
+    def test_constant_rate_factor_error(self, constant_rate_factor):
+        exc_msg = r"Constant rate factor must be an integer in the range \[0, 51\]."
+        with pytest.raises(ValueError, match=exc_msg):
+            VideoCompression(video_format="", constant_rate_factor=constant_rate_factor)
+
+    def test_non_spatio_temporal_data_error(self, image_batch):
+        test_input = image_batch
+        video_compression = VideoCompression(video_format="")
+
+        exc_msg = "Video compression can only be applied to spatio-temporal data."
+        with pytest.raises(ValueError, match=exc_msg):
+            video_compression(test_input)
+
+
+if __name__ == "__main__":
+    pytest.cmdline.main("-q -s {} --mlFramework=tensorflow --durations=0".format(__file__).split(" "))


### PR DESCRIPTION
# Description

Add H.264/MPEG-4 AVC video compression defense, which provides a small wrapper around `ffmpeg-python` to facilitate video compression.

Closes #408 

## Type of change

- [x] New feature (non-breaking)

# Testing

Several unit tests were provided. Furthermore, the preprocessor has been tested on a real `avi` and `mp4` video source in order to visually verify that it is possible to lower its quality and compression rate.

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
