### PR TITLE
Improve default values for apply_{fit,predict} arguments in defense preprocessors

### DIFF
--- a/art/defences/preprocessor/gaussian_augmentation.py
+++ b/art/defences/preprocessor/gaussian_augmentation.py
@@ -62,10 +62,15 @@ class GaussianAugmentation(Preprocessor):
         """
         super(GaussianAugmentation, self).__init__()
         self._is_fitted = True
-        if augmentation and apply_fit and apply_predict:
+        if augmentation and not apply_fit and apply_predict:
             raise ValueError(
                 "If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict` must be `False`."
             )
+        if augmentation and not (apply_fit or apply_predict):
+            raise ValueError(
+                "If `augmentation` is `True`, then `apply_fit` and `apply_predict` can't be both `False`."
+            )
+
         self._apply_fit = apply_fit
         self._apply_predict = apply_predict
         self.set_params(sigma=sigma, augmentation=augmentation, ratio=ratio, clip_values=clip_values)

--- a/art/defences/preprocessor/jpeg_compression.py
+++ b/art/defences/preprocessor/jpeg_compression.py
@@ -60,7 +60,7 @@ class JpegCompression(Preprocessor):
         channel_index=Deprecated,
         channels_first=False,
         apply_fit=True,
-        apply_predict=False,
+        apply_predict=True,
     ):
         """
         Create an instance of JPEG compression.

--- a/art/defences/preprocessor/mp3_compression.py
+++ b/art/defences/preprocessor/mp3_compression.py
@@ -45,7 +45,7 @@ class Mp3Compression(Preprocessor):
 
     @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
-        self, sample_rate, channel_index=Deprecated, channels_first=False, apply_fit=True, apply_predict=False
+        self, sample_rate, channel_index=Deprecated, channels_first=False, apply_fit=False, apply_predict=True
     ):
         """
         Create an instance of MP3 compression.

--- a/art/defences/preprocessor/resample.py
+++ b/art/defences/preprocessor/resample.py
@@ -46,7 +46,7 @@ class Resample(Preprocessor):
 
     @deprecated_keyword_arg("channel_index", end_version="1.5.0", replaced_by="channels_first")
     def __init__(
-        self, sr_original, sr_new, channel_index=Deprecated, channels_first=False, apply_fit=True, apply_predict=False
+        self, sr_original, sr_new, channel_index=Deprecated, channels_first=False, apply_fit=False, apply_predict=True
     ):
         """
         Create an instance of the resample preprocessor.

--- a/tests/defences/test_gaussian_augmentation.py
+++ b/tests/defences/test_gaussian_augmentation.py
@@ -78,11 +78,18 @@ class TestGaussianAugmentation(unittest.TestCase):
     def test_failure_augmentation_fit_predict(self):
         # Assert that value error is raised
         with self.assertRaises(ValueError) as context:
-            _ = GaussianAugmentation(augmentation=True, apply_fit=True, apply_predict=True)
+            _ = GaussianAugmentation(augmentation=True, apply_fit=False, apply_predict=True)
 
         self.assertTrue(
             "If `augmentation` is `True`, then `apply_fit` must be `True` and `apply_predict`"
             " must be `False`." in str(context.exception)
+        )
+        with self.assertRaises(ValueError) as context:
+            _ = GaussianAugmentation(augmentation=True, apply_fit=False, apply_predict=False)
+
+        self.assertTrue(
+            "If `augmentation` is `True`, then `apply_fit` and `apply_predict` can't be both `False`."
+            in str(context.exception)
         )
 
 


### PR DESCRIPTION
# Description

This PR changes the default values for the `apply_fit` and `apply_predict` arguments in the following defense preprocessors:
* `JpegCompression`
* `Mp3Compression`
* `Resample`
* `GaussianAugmentation`

The goal is to streamline default values with their relevant literature reference.

Fixes #434 

## Type of change

- [x] ~Bug~ fix (non-breaking)

# Testing

Additional checks were added for `GaussianAugmentation`. The related test case has been extended.

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
