### PR TITLE
Keras wildcards

### DIFF
--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -284,7 +284,8 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         :rtype: `np.ndarray`
         """
         # Check shape of `x` because of custom function for `_loss_gradients`
-        if self._input_shape != x.shape[1:]:
+        shape_match = (np.array(self._input_shape) == np.array(x.shape[1:])) + (np.array(self._input_shape) == None)
+        if not shape_match.all():
             raise ValueError(
                 "Error when checking x: expected x to have shape {} but got array with shape {}".format(
                     self._input_shape, x.shape[1:]

--- a/art/estimators/classification/keras.py
+++ b/art/estimators/classification/keras.py
@@ -284,8 +284,8 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         :rtype: `np.ndarray`
         """
         # Check shape of `x` because of custom function for `_loss_gradients`
-        shape_match = (np.array(self._input_shape) == np.array(x.shape[1:])) + (np.array(self._input_shape) == None)
-        if not shape_match.all():
+        shape_match = [i is None or i == j for i,j in zip(self._input_shape, x.shape[1:])]
+        if not all(shape_match):
             raise ValueError(
                 "Error when checking x: expected x to have shape {} but got array with shape {}".format(
                     self._input_shape, x.shape[1:]
@@ -336,7 +336,8 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
             raise ValueError("Label %s is out of range." % str(label))
 
         # Check shape of `x` because of custom function for `_loss_gradients`
-        if self._input_shape != x.shape[1:]:
+        shape_match = [i is None or i == j for i,j in zip(self._input_shape, x.shape[1:])]
+        if not all(shape_match):
             raise ValueError(
                 "Error when checking x: expected x to have shape {} but got array with shape {}".format(
                     self._input_shape, x.shape[1:]
@@ -355,7 +356,7 @@ class KerasClassifier(ClassGradientsMixin, ClassifierMixin, KerasEstimator):
         elif isinstance(label, (int, np.integer)):
             # Compute the gradients only w.r.t. the provided label
             gradients = np.swapaxes(np.array(self._class_gradients_idx[label]([x_preprocessed])), 0, 1)
-            assert gradients.shape == (x_preprocessed.shape[0], 1) + self.input_shape
+            assert gradients.shape == (x_preprocessed.shape[0], 1) + x_preprocessed.shape[1:]
 
         else:
             # For each sample, compute the gradients w.r.t. the indicated target class (possibly distinct)

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -510,8 +510,11 @@ class TestKerasClassifierTensorFlow(TestBase):
         shapes = [(1, 10, 1), (1, 20, 1)]
         for shape in shapes:
             x = np.random.normal(size=shape)
-            gradients = classifier.loss_gradient(x, y=[1])
-            self.assertEqual(gradients.shape, shape)
+            loss_gradient = classifier.loss_gradient(x, y=[1])
+            self.assertEqual(loss_gradient.shape, shape)
+
+            class_gradient = classifier.class_gradient(x, 0)
+            self.assertEqual(class_gradient[0].shape, shape)
 
     def test_functional_model(self):
         # Need to update the functional_model code to produce a model with more than one input and output layers...

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -34,7 +34,8 @@ from art.data_generators import KerasDataGenerator
 from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
 from art.estimators.classification.keras import KerasClassifier, generator_fit
 from art.utils import Deprecated
-from tests.utils import TestBase, get_image_classifier_kr_tf, master_seed
+from tests.utils import TestBase, get_image_classifier_kr_tf, get_image_classifier_kr_tf_with_wildcard, master_seed, \
+    get_image_classifier_kr_with_wildcard
 
 if tf.__version__[0] == "2":
     tf.compat.v1.disable_eager_execution()
@@ -502,6 +503,16 @@ class TestKerasClassifierTensorFlow(TestBase):
             ]
         )
         np.testing.assert_array_almost_equal(gradients[0, :, 14, 0], expected_gradients_2, decimal=4)
+
+    def test_loss_gradient_with_wildcard(self):
+        classifier = get_image_classifier_kr_with_wildcard()
+
+        # Test gradient
+        shapes = [(1, 10, 1), (1, 20, 1)]
+        for shape in shapes:
+            x = np.random.normal(size=shape)
+            gradients = classifier.loss_gradient(x, y=[1])
+            self.assertEqual(gradients.shape, shape)
 
     def test_functional_model(self):
         # Need to update the functional_model code to produce a model with more than one input and output layers...

--- a/tests/estimators/classification/test_keras_tf.py
+++ b/tests/estimators/classification/test_keras_tf.py
@@ -34,8 +34,7 @@ from art.data_generators import KerasDataGenerator
 from art.defences.preprocessor import FeatureSqueezing, JpegCompression, SpatialSmoothing
 from art.estimators.classification.keras import KerasClassifier, generator_fit
 from art.utils import Deprecated
-from tests.utils import TestBase, get_image_classifier_kr_tf, get_image_classifier_kr_tf_with_wildcard, master_seed, \
-    get_image_classifier_kr_with_wildcard
+from tests.utils import TestBase, get_image_classifier_kr_tf, get_image_classifier_kr_tf_with_wildcard, master_seed
 
 if tf.__version__[0] == "2":
     tf.compat.v1.disable_eager_execution()
@@ -505,7 +504,7 @@ class TestKerasClassifierTensorFlow(TestBase):
         np.testing.assert_array_almost_equal(gradients[0, :, 14, 0], expected_gradients_2, decimal=4)
 
     def test_loss_gradient_with_wildcard(self):
-        classifier = get_image_classifier_kr_with_wildcard()
+        classifier = get_image_classifier_kr_tf_with_wildcard()
 
         # Test gradient
         shapes = [(1, 10, 1), (1, 20, 1)]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -750,6 +750,60 @@ def get_image_classifier_kr_tf_binary():
     return krc
 
 
+def get_image_classifier_kr_tf_with_wildcard():
+    """
+    Standard Tensorflow-Keras binary classifier for unit testing
+
+    :return: KerasClassifier
+    """
+    # pylint: disable=E0401
+    import tensorflow as tf
+
+    if tf.__version__[0] == "2":
+        tf.compat.v1.disable_eager_execution()
+    from tensorflow.keras.models import Sequential
+    from tensorflow.keras.layers import Dense, Conv1D, LSTM
+
+    from art.estimators.classification.keras import KerasClassifier
+
+    # Create simple CNN
+    model = Sequential()
+    model.add(Conv1D(1, 3, activation="relu", input_shape=(None, 1)))
+    model.add(LSTM(4))
+    model.add(Dense(2, activation="softmax"))
+    model.compile(loss="categorical_crossentropy", optimizer="adam")
+
+    # Get classifier
+    krc = KerasClassifier(model)
+
+    return krc
+
+
+def get_image_classifier_kr_with_wildcard():
+    """
+    Standard Tensorflow-Keras binary classifier for unit testing
+
+    :return: KerasClassifier
+    """
+    # pylint: disable=E0401
+    from keras.models import Sequential
+    from keras.layers import Dense, Conv1D, LSTM
+
+    from art.estimators.classification.keras import KerasClassifier
+
+    # Create simple CNN
+    model = Sequential()
+    model.add(Conv1D(1, 3, activation="relu", input_shape=(None, 1)))
+    model.add(LSTM(4))
+    model.add(Dense(2, activation="softmax"))
+    model.compile(loss="categorical_crossentropy", optimizer="adam")
+
+    # Get classifier
+    krc = KerasClassifier(model)
+
+    return krc
+
+
 def get_image_classifier_pt(from_logits=False, load_init=True):
     """
     Standard PyTorch classifier for unit testing.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -771,32 +771,7 @@ def get_image_classifier_kr_tf_with_wildcard():
     model.add(Conv1D(1, 3, activation="relu", input_shape=(None, 1)))
     model.add(LSTM(4))
     model.add(Dense(2, activation="softmax"))
-    model.compile(loss="categorical_crossentropy", optimizer="adam")
-
-    # Get classifier
-    krc = KerasClassifier(model)
-
-    return krc
-
-
-def get_image_classifier_kr_with_wildcard():
-    """
-    Standard Tensorflow-Keras binary classifier for unit testing
-
-    :return: KerasClassifier
-    """
-    # pylint: disable=E0401
-    from keras.models import Sequential
-    from keras.layers import Dense, Conv1D, LSTM
-
-    from art.estimators.classification.keras import KerasClassifier
-
-    # Create simple CNN
-    model = Sequential()
-    model.add(Conv1D(1, 3, activation="relu", input_shape=(None, 1)))
-    model.add(LSTM(4))
-    model.add(Dense(2, activation="softmax"))
-    model.compile(loss="categorical_crossentropy", optimizer="adam")
+    model.compile(loss="binary_crossentropy", optimizer="adam")
 
     # Get classifier
     krc = KerasClassifier(model)


### PR DESCRIPTION
# Description

This PR modifies the input shape checks in the `loss_gradient` function of the `KerasClassifier` to allow for input shapes that include wildcards.

Fixes #457

## Type of change

Please check all relevant options.

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Consider listing any relevant details of your test configuration.

- [x] Local unit tests

**Test Configuration**:
- MacOS, Python 3.6, Keras 2.2.1, TensorFlow 1.15.0, ART dev_1.3.0 branch

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
