### PR TITLE
Fix and rerun audio and video notebooks

### DIFF
--- a/notebooks/adversarial_action_recognition.ipynb
+++ b/notebooks/adversarial_action_recognition.ipynb
@@ -41,9 +41,6 @@
     "import os\n",
     "import tempfile\n",
     "\n",
-    "from art.attacks import FastGradientMethod, FrameSaliencyAttack\n",
-    "from art.estimators.classification import MXClassifier\n",
-    "from art.config import ART_DATA_PATH\n",
     "import decord\n",
     "from gluoncv import utils\n",
     "from gluoncv.data.transforms import video\n",
@@ -56,6 +53,11 @@
     "from mxnet import gluon, nd, image\n",
     "from mxnet.gluon.data.vision import transforms\n",
     "import numpy as np\n",
+    "\n",
+    "from art.attacks.evasion import FastGradientMethod, FrameSaliencyAttack\n",
+    "from art.config import ART_DATA_PATH\n",
+    "from art.defences.preprocessor import VideoCompression\n",
+    "from art.estimators.classification import MXClassifier\n",
     "\n",
     "# set global variables\n",
     "PRETRAINED_MODEL_NAME = 'i3d_resnet50_v1_ucf101'\n",
@@ -105,7 +107,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`/Users/mathieu/.art/data/v_Basketball_g01_c01.avi` has been downloaded and preprocessed.\n"
+      "`/home/hessel/.art/data/v_Basketball_g01_c01.avi` has been downloaded and preprocessed.\n"
      ]
     }
    ],
@@ -272,8 +274,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2min 1s, sys: 2.19 s, total: 2min 4s\n",
-      "Wall time: 1min 53s\n"
+      "CPU times: user 3min 7s, sys: 1.77 s, total: 3min 9s\n",
+      "Wall time: 2min 48s\n"
      ]
     }
    ],
@@ -294,10 +296,10 @@
      "output_type": "stream",
      "text": [
       "The video sample clip is classified to be\n",
-      "\t[ThrowDiscus], with probability 0.267.\n",
-      "\t[Hammering], with probability 0.243.\n",
-      "\t[TennisSwing], with probability 0.154.\n",
-      "\t[HulaHoop], with probability 0.083.\n",
+      "\t[ThrowDiscus], with probability 0.266.\n",
+      "\t[Hammering], with probability 0.244.\n",
+      "\t[TennisSwing], with probability 0.155.\n",
+      "\t[HulaHoop], with probability 0.082.\n",
       "\t[JavelinThrow], with probability 0.055.\n"
      ]
     }
@@ -316,7 +318,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`/Users/mathieu/.art/data/adversarial_basketball.gif` has been successfully created.\n"
+      "`/home/hessel/.art/data/adversarial_basketball.gif` has been successfully created.\n"
      ]
     }
    ],
@@ -359,15 +361,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4min 31s, sys: 4.44 s, total: 4min 35s\n",
-      "Wall time: 4min 13s\n"
+      "CPU times: user 6min 48s, sys: 3.1 s, total: 6min 52s\n",
+      "Wall time: 6min 6s\n"
      ]
     }
    ],
@@ -380,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -388,9 +390,9 @@
      "output_type": "stream",
      "text": [
       "The video sample clip is classified to be\n",
-      "\t[TennisSwing], with probability 0.495.\n",
-      "\t[Basketball], with probability 0.427.\n",
-      "\t[VolleyballSpiking], with probability 0.041.\n",
+      "\t[TennisSwing], with probability 0.497.\n",
+      "\t[Basketball], with probability 0.425.\n",
+      "\t[VolleyballSpiking], with probability 0.040.\n",
       "\t[SoccerJuggling], with probability 0.014.\n",
       "\t[TableTennisShot], with probability 0.009.\n"
      ]
@@ -403,14 +405,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "`/Users/mathieu/.art/data/adversarial_basketball_sparse.gif` has been successfully created.\n"
+      "`/home/hessel/.art/data/adversarial_basketball_sparse.gif` has been successfully created.\n"
      ]
     }
    ],
@@ -422,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -440,6 +442,56 @@
     "x_diff = np.reshape(x_diff, x_diff.shape[:2] + (np.prod(x_diff.shape[2:]), ))\n",
     "x_diff_norm = np.sign(np.round(np.linalg.norm(x_diff, axis=-1), decimals=4))\n",
     "print(f\"Number of perturbed frames: {int(np.sum(x_diff_norm))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Apply H.264 compression defense\n",
+    "\n",
+    "Next we are going to apply a simple input preprocessing defense, namely `VideoCompression`. Ideally, we want this defense to result in correct predictions when applied both to the original and the adversarial video input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The video sample clip is classified to be\n",
+      "\t[Basketball], with probability 0.516.\n",
+      "\t[TennisSwing], with probability 0.443.\n",
+      "\t[VolleyballSpiking], with probability 0.018.\n",
+      "\t[TableTennisShot], with probability 0.010.\n",
+      "\t[SoccerJuggling], with probability 0.005.\n",
+      "The video sample clip is classified to be\n",
+      "\t[Basketball], with probability 0.697.\n",
+      "\t[TennisSwing], with probability 0.242.\n",
+      "\t[VolleyballSpiking], with probability 0.026.\n",
+      "\t[SoccerJuggling], with probability 0.011.\n",
+      "\t[TableTennisShot], with probability 0.009.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# initialize VideoCompression defense\n",
+    "video_compression = VideoCompression(video_format=\"avi\", constant_rate_factor=30, channels_first=True)\n",
+    "\n",
+    "# apply defense to original input\n",
+    "adv_sample_input_compressed = video_compression(adv_sample_input * 255)[0] / 255\n",
+    "\n",
+    "# apply defense to sparse adversarial sample\n",
+    "adv_sample_sparse_compressed = video_compression(adv_sample_sparse * 255)[0] / 255\n",
+    "\n",
+    "# print the resulting predictions on compressed original input\n",
+    "_ = predict_top_k((adv_sample_input_compressed-mean)/std, model)\n",
+    "\n",
+    "# print the resulting predictions on sparse adversarial sample\n",
+    "_ = predict_top_k((adv_sample_sparse_compressed-mean)/std, model)"
    ]
   },
   {

--- a/notebooks/adversarial_audio_examples.ipynb
+++ b/notebooks/adversarial_audio_examples.ipynb
@@ -95,7 +95,7 @@
     "    \"\"\"Dataset object for the AudioMNIST data set.\"\"\"\n",
     "    def __init__(self, root_dir, transform=None, verbose=False):\n",
     "        self.root_dir = root_dir\n",
-    "        self.audio_list = glob.glob(f\"{root_dir}/*/*.wav\")\n",
+    "        self.audio_list = sorted(glob.glob(f\"{root_dir}/*/*.wav\"))\n",
     "        self.transform = transform\n",
     "        self.verbose = verbose\n",
     "\n",
@@ -334,7 +334,7 @@
    ],
    "source": [
     "# load a test sample\n",
-    "sample = audiomnist_test[1]\n",
+    "sample = audiomnist_test[3559]\n",
     "\n",
     "waveform = sample['input']\n",
     "label = sample['digit']\n",
@@ -470,7 +470,7 @@
    ],
    "source": [
     "# load a test sample\n",
-    "sample = audiomnist_test[444]\n",
+    "sample = audiomnist_test[3773]\n",
     "\n",
     "waveform = sample['input']\n",
     "label = sample['digit']\n",
@@ -589,7 +589,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -602,7 +604,7 @@
    ],
    "source": [
     "# load a test sample\n",
-    "sample = audiomnist_test[1021]\n",
+    "sample = audiomnist_test[5905]\n",
     "\n",
     "waveform = sample['input']\n",
     "label = sample['digit']\n",
@@ -733,32 +735,21 @@
     "# initialize Mp3Compression defense\n",
     "mp3_compression = Mp3Compression(sample_rate=DOWNSAMPLED_SAMPLING_RATE, channels_first=True)\n",
     "\n",
-    "# load a test sample\n",
-    "sample = audiomnist_test[1021]\n",
-    "label = sample['digit']\n",
+    "# apply defense to original input\n",
+    "waveform_int16 = np.clip(np.round(torch.unsqueeze(waveform, 0).numpy()), -2**15, 2**15-1).astype(np.int16)\n",
+    "waveform_mp3 = mp3_compression(waveform_int16)[0].astype(np.float32)\n",
     "\n",
-    "# apply defense  to original input\n",
-    "waveform_int16 = np.clip(np.round(torch.unsqueeze(sample['input'], 0).numpy()), -2**15, 2**15-1).astype(np.int16)\n",
-    "waveform_mp3 = mp3_compression(waveform_int16).astype(np.float32)\n",
-    "\n",
-    "# craft adversarial example with PGD\n",
-    "epsilon = 0.35\n",
-    "pgd = ProjectedGradientDescent(classifier_art, eps=epsilon)\n",
-    "adv_waveform = pgd.generate(\n",
-    "    x=waveform_mp3\n",
-    ")\n",
-    "\n",
-    "# apply defense  to adversarial sample\n",
+    "# apply defense to adversarial sample\n",
     "adv_waveform_int16 = np.clip(np.round(adv_waveform), -2**15, 2**15-1).astype(np.int16)\n",
-    "adv_waveform_mp3 = mp3_compression(adv_waveform_int16).astype(np.float32)\n",
+    "adv_waveform_mp3 = mp3_compression(adv_waveform_int16)[0].astype(np.float32)\n",
     "\n",
     "# evaluate the classifier on the adversarial example\n",
     "with torch.no_grad():\n",
-    "    _, pred = torch.max(model(torch.Tensor(waveform_mp3)), 1)\n",
+    "    _, pred_mp3 = torch.max(model(torch.Tensor(waveform_mp3)), 1)\n",
     "    _, pred_adv_mp3 = torch.max(model(torch.Tensor(adv_waveform_mp3)), 1)\n",
     "\n",
     "# print results\n",
-    "print(f\"Original prediction with MP3 compression (ground truth):\\t{pred.tolist()[0]} ({label})\")\n",
+    "print(f\"Original prediction with MP3 compression (ground truth):\\t{pred_mp3.tolist()[0]} ({label})\")\n",
     "print(f\"Adversarial prediction with MP3 compression:\\t\\t\\t{pred_adv_mp3.tolist()[0]}\")"
    ]
   },
@@ -783,7 +774,7 @@
     "    input_shape=[1, DOWNSAMPLED_SAMPLING_RATE],\n",
     "    nb_classes=10,\n",
     "    clip_values=(-2**15, 2**15 - 1),\n",
-    "    preprocessing_defences=[mp3_compression]\n",
+    "    preprocessing_defences=[mp3_compression],\n",
     ")"
    ]
   },
@@ -796,8 +787,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Original prediction with adaptive classifier (ground truth):\t8 (8)\n",
-      "Adversarial prediction with adaptive classiefier:\t\t3\n"
+      "Original prediction with adaptive classifier (ground truth):\t1 (8)\n",
+      "Adversarial prediction with adaptive classifier:\t\t1\n"
      ]
     }
    ],
@@ -814,7 +805,7 @@
     "\n",
     "# print results\n",
     "print(f\"Original prediction with adaptive classifier (ground truth):\\t{pred_def} ({label})\")\n",
-    "print(f\"Adversarial prediction with adaptive classiefier:\\t\\t{pred_adv_def}\")"
+    "print(f\"Adversarial prediction with adaptive classifier:\\t\\t{pred_adv_def}\")"
    ]
   },
   {


### PR DESCRIPTION
# Description

* Fix random sorting of the data loader in the audio notebook.
* Add video defense demonstration to video notebook.
* Ensure that notebooks run on the recent `dev_1.3.0` branch. 

## Type of change

- [x] ~Bug~ fix (non-breaking)
- [x] New feature (non-breaking)


# Testing

**Test Configuration**:
- Fedora 31
- Python 3.6.10
- ART 1.3.0 development

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings