### PR TITLE
Fix DeepFool

### DIFF
--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -78,6 +78,12 @@ class DeepFool(EvasionAttack):
         self.nb_grads = nb_grads
         self.batch_size = batch_size
         self._check_params()
+        if self.estimator.clip_values is None:
+            logger.warning(
+                "The `clip_values` attribute of the estimator is `None`, therefore this instance of DeepFool will by "
+                "default generate adversarial perturbations scaled for input values in the range [0, 1] but not clip "
+                "the adversarial example."
+            )
 
     def generate(self, x: np.ndarray, y: Optional[np.ndarray] = None, **kwargs) -> np.ndarray:
         """
@@ -143,7 +149,8 @@ class DeepFool(EvasionAttack):
                 # Add perturbation and clip result
                 if self.estimator.clip_values is not None:
                     batch[active_indices] = np.clip(
-                        batch[active_indices] + r_var[active_indices],
+                        batch[active_indices]
+                        + r_var[active_indices] * (self.estimator.clip_values[1] - self.estimator.clip_values[0]),
                         self.estimator.clip_values[0],
                         self.estimator.clip_values[1],
                     )

--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -34,7 +34,7 @@ from art.estimators.classification.classifier import (
     ClassifierGradients,
 )
 from art.attacks.attack import EvasionAttack
-from art.utils import compute_success
+from art.utils import compute_success, is_probability
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +95,12 @@ class DeepFool(EvasionAttack):
         """
         x_adv = x.astype(ART_NUMPY_DTYPE)
         preds = self.estimator.predict(x, batch_size=self.batch_size)
+
+        if is_probability(preds[0]):
+            logger.warning(
+                "It seems that the attacked model is predicting probabilities. DeepFool expects logits as "
+                "model output to achieve its full attack strength."
+            )
 
         # Determine the class labels for which to compute the gradients
         use_grads_subset = self.nb_grads < self.estimator.nb_classes

--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -106,7 +106,7 @@ class DeepFool(EvasionAttack):
         # Compute perturbation with implicit batching
         for batch_id in trange(int(np.ceil(x_adv.shape[0] / float(self.batch_size))), desc="DeepFool"):
             batch_index_1, batch_index_2 = batch_id * self.batch_size, (batch_id + 1) * self.batch_size
-            batch = x_adv[batch_index_1:batch_index_2]
+            batch = x_adv[batch_index_1:batch_index_2].copy()
 
             # Get predictions and gradients for batch
             f_batch = preds[batch_index_1:batch_index_2]

--- a/art/attacks/evasion/deepfool.py
+++ b/art/attacks/evasion/deepfool.py
@@ -98,8 +98,8 @@ class DeepFool(EvasionAttack):
 
         if is_probability(preds[0]):
             logger.warning(
-                "It seems that the attacked model is predicting probabilities. DeepFool expects logits as "
-                "model output to achieve its full attack strength."
+                "It seems that the attacked model is predicting probabilities. DeepFool expects logits as model output "
+                "to achieve its full attack strength."
             )
 
         # Determine the class labels for which to compute the gradients


### PR DESCRIPTION
# Description

This pull request fixes the overshoot step of `DeepFool`, adds warnings if the estimator predicts probabilities instead of logits and if `clip_values` are `None` and scales the perturbations to the `clip_values`.

Fixes #219 #475 

## Type of change

Please check all relevant options.

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
