### PR TITLE
Make internal import paths explicit for AdversarialPatch and PGD

### DIFF
--- a/art/attacks/evasion/__init__.py
+++ b/art/attacks/evasion/__init__.py
@@ -1,11 +1,9 @@
 """
 Module providing evasion attacks under a common interface.
 """
-from art.attacks.evasion.adversarial_patch.adversarial_patch import (
-    AdversarialPatch,
-    AdversarialPatchNumpy,
-    AdversarialPatchTensorFlowV2,
-)
+from art.attacks.evasion.adversarial_patch.adversarial_patch import AdversarialPatch
+from art.attacks.evasion.adversarial_patch.adversarial_patch_numpy import AdversarialPatchNumpy
+from art.attacks.evasion.adversarial_patch.adversarial_patch_tensorflow import AdversarialPatchTensorFlowV2
 from art.attacks.evasion.boundary import BoundaryAttack
 from art.attacks.evasion.carlini import CarliniL2Method, CarliniLInfMethod
 from art.attacks.evasion.decision_tree_attack import DecisionTreeAttack
@@ -16,10 +14,14 @@ from art.attacks.evasion.hclu import HighConfidenceLowUncertainty
 from art.attacks.evasion.hop_skip_jump import HopSkipJump
 from art.attacks.evasion.iterative_method import BasicIterativeMethod
 from art.attacks.evasion.newtonfool import NewtonFool
-from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent import (
-    ProjectedGradientDescent,
+from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent import ProjectedGradientDescent
+from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent_numpy import (
     ProjectedGradientDescentNumpy,
+)
+from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent_pytorch import (
     ProjectedGradientDescentPyTorch,
+)
+from art.attacks.evasion.projected_gradient_descent.projected_gradient_descent_tensorflow_v2 import (
     ProjectedGradientDescentTensorFlowV2,
 )
 from art.attacks.evasion.saliency_map import SaliencyMapMethod


### PR DESCRIPTION
Signed-off-by: Beat Buesser <beat.buesser@ie.ibm.com>

# Description

This pull request makes internal imports for `AdversarialPatch` and `ProjectedGradientDescent` explicit.

Fixes #477 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
